### PR TITLE
Enable external redis server

### DIFF
--- a/charts/kutt/templates/deployment.yaml
+++ b/charts/kutt/templates/deployment.yaml
@@ -120,6 +120,21 @@ spec:
                   name: {{ include "redis.secretName" .Subcharts.redis }}
                   key: {{ include "redis.secretPasswordKey" .Subcharts.redis }}
             {{- end }}
+            {{- else if .Values.redis.auth.hostname }}
+            - name: REDIS_HOST
+              value: {{ .Values.redis.auth.hostname }}
+            - name: REDIS_PORT
+              value: {{ .Values.redis.auth.port | quote }}
+            {{- if .Values.redis.auth.existingSecret }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.redis.auth.existingSecret }}
+                  key: redis_password
+            {{- else if .Values.redis.auth.password }}
+            - name: REDIS_PASSWORD
+              value: {{ .Values.redis.auth.password }}
+            {{- end }}
             {{- end }}
           {{- with .Values.securityContext }}
           securityContext:

--- a/charts/kutt/values.schema.json
+++ b/charts/kutt/values.schema.json
@@ -213,6 +213,18 @@
                     "properties": {
                         "enabled": {
                             "type": "boolean"
+                        },
+                        "hostname": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "password": {
+                            "type": "string"
+                        },
+                        "existingSecret": {
+                            "type": "string"
                         }
                     }
                 },

--- a/charts/kutt/values.yaml
+++ b/charts/kutt/values.yaml
@@ -78,6 +78,14 @@ redis:
   enabled: true
   auth:
     enabled: true
+    # @param redis.auth.hostname External Redis hostname
+    hostname: ""
+    # @param redis.auth.port External Redis port
+    port: 6379
+    # @param redis.auth.password External Redis password (if auth enabled)
+    password: ""
+    # @param redis.auth.hostname External PostgreSQL database secrets. The secret has to contain the key `db_password`
+    existingSecret: ""
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
At present chart does not allow to easily use external Redis - it requires overwriting of $ENV variables.

This feature adds support for external Redis server.