### PR TITLE
Support incoming tls

### DIFF
--- a/charts/maildev/templates/deployment.yaml
+++ b/charts/maildev/templates/deployment.yaml
@@ -176,6 +176,9 @@ spec:
               mountPath: /etc/maildev
               subPath: auto-relay-rules.json
             {{- end }}
+            {{- if .Values.maildev.extraVolumeMounts }}
+            {{- toYaml .Values.maildev.extraVolumeMounts | nindent 12 }}
+            {{- end }}
       volumes:
         - name: data
           {{- if .Values.maildev.persistence.enabled }}
@@ -191,6 +194,9 @@ spec:
             items:
               - key: auto-relay-rules.json
                 path: auto-relay-rules.json
+        {{- end }}
+        {{- if .Values.maildev.extraVolumes }}
+        {{- toYaml .Values.maildev.extraVolumes | nindent 8 }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/maildev/templates/deployment.yaml
+++ b/charts/maildev/templates/deployment.yaml
@@ -107,11 +107,11 @@ spec:
             - name: MAILDEV_OUTGOING_HOST
               value: {{ .Values.maildev.config.smtp.outgoing.host | quote }}
             {{- end }}
-            {{- if .Values.maildev.config.smtp.outgoing.host }}
+            {{- if .Values.maildev.config.smtp.outgoing.port }}
             - name: MAILDEV_OUTGOING_PORT
               value: {{ .Values.maildev.config.smtp.outgoing.port | quote }}
             {{- end }}
-            {{- if .Values.maildev.config.smtp.outgoing.host }}
+            {{- if .Values.maildev.config.smtp.outgoing.password }}
             - name: MAILDEV_OUTGOING_PASS
               valueFrom:
                 secretKeyRef:

--- a/charts/maildev/templates/deployment.yaml
+++ b/charts/maildev/templates/deployment.yaml
@@ -91,6 +91,18 @@ spec:
                   name: {{ include "maildev.smtp.incoming.secretName" . }}
                   key: smtp-incoming-password
             {{- end }}
+            {{- if .Values.maildev.config.smtp.incoming.secure }}
+            - name: MAILDEV_INCOMING_SECURE
+              value: {{ .Values.maildev.config.smtp.incoming.secure | quote }}
+            {{- end }}
+            {{- if .Values.maildev.config.smtp.incoming.cert }}
+            - name: MAILDEV_INCOMING_CERT
+              value: {{ .Values.maildev.config.smtp.incoming.cert | quote }}
+            {{- end }}
+            {{- if .Values.maildev.config.smtp.incoming.key }}
+            - name: MAILDEV_INCOMING_KEY
+              value: {{ .Values.maildev.config.smtp.incoming.key | quote }}
+            {{- end }}
             {{- if .Values.maildev.config.smtp.outgoing.host }}
             - name: MAILDEV_OUTGOING_HOST
               value: {{ .Values.maildev.config.smtp.outgoing.host | quote }}

--- a/charts/maildev/templates/deployment.yaml
+++ b/charts/maildev/templates/deployment.yaml
@@ -122,7 +122,7 @@ spec:
             - name: MAILDEV_OUTGOING_USER
               value: {{ .Values.maildev.config.smtp.outgoing.username | quote }}
             {{- end }}
-            # Web Settingss
+            # Web Settings
             {{- if .Values.maildev.config.web.username }}
             - name: MAILDEV_WEB_USER
               value: {{ .Values.maildev.config.web.username | quote }}


### PR DESCRIPTION
Hi!

This MR adds support for incoming SMTP TLS and extra volume mounts (to mount the key and cert).

Summary:
- Add configuration options for incoming SMTP
- Support extra volume mounts
- Fix typos and mistakes in deployment.yaml

Feel free to make suggestions or adapt it to your taste.

Thanks for the chart BTW :-)