### PR TITLE
Update hpa.yaml for apiVersion: autoscaling/v2

### DIFF
--- a/charts/headwind-mdm/templates/hpa.yaml
+++ b/charts/headwind-mdm/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "headwind-mdm.fullname" . }}


### PR DESCRIPTION
apiVersion: autoscaling/v2 is already out of beta for the recent stable kubernetes versions