### PR TITLE
[shlink-backend] Add schema annotation to support env var refs

### DIFF
--- a/charts/shlink-backend/Chart.yaml
+++ b/charts/shlink-backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: shlink-backend
 description: A PHP-based self-hosted URL shortener that can be used to serve shortened URLs under your own domain.
 type: application
-version: 4.5.5
+version: 4.5.6
 appVersion: "3.7.4"
 home: https://github.com/christianhuth/helm-charts
 icon: https://shlink.io/images/shlink-logo-blue.svg
@@ -35,8 +35,8 @@ dependencies:
     condition: redis.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Changelog
+    - kind: fixed
+      description: Loosened helm schema type restrictions to allow valueFrom refs in environment variables
   artifacthub.io/signKey: |
     fingerprint: EE24F8BB6D099E78FD704F83B5ECDBCDDD485D0E
     url: https://charts.christianhuth.de/public.key

--- a/charts/shlink-backend/README.md
+++ b/charts/shlink-backend/README.md
@@ -51,10 +51,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| env[0].name | string | `"DEFAULT_DOMAIN"` |  |
-| env[0].value | string | `"doma.in"` |  |
-| env[1].name | string | `"IS_HTTPS_ENABLED"` |  |
-| env[1].value | string | `"false"` |  |
+| env | list | `[{"name":"DEFAULT_DOMAIN","value":"doma.in"},{"name":"IS_HTTPS_ENABLED","value":"false"}]` | Environment variables. Supports both direct values and references to ConfigMaps/Secrets. See https://shlink.io/documentation/environment-variables/ for a complete list |
 | fullnameOverride | string | `""` | String to fully override `"shlink-backend.fullname"` |
 | image.pullPolicy | string | `"Always"` | image pull policy |
 | image.repository | string | `"shlinkio/shlink"` | image repository |

--- a/charts/shlink-backend/values.schema.json
+++ b/charts/shlink-backend/values.schema.json
@@ -44,53 +44,94 @@
       "type": "object"
     },
     "env": {
-      "description": "see https://shlink.io/documentation/environment-variables/ for a complete list",
+      "description": "Environment variables. Supports both direct values and references to ConfigMaps/Secrets. See https://shlink.io/documentation/environment-variables/ for a complete list",
       "items": {
-        "anyOf": [
+        "oneOf": [
           {
-            "properties": {
-              "name": {
-                "default": "DEFAULT_DOMAIN",
-                "required": [],
-                "title": "name",
-                "type": "string"
-              },
-              "value": {
-                "default": "doma.in",
-                "required": [],
-                "title": "value",
-                "type": "string"
-              }
-            },
             "required": [
               "name",
               "value"
-            ],
-            "type": "object"
+            ]
           },
           {
-            "properties": {
-              "name": {
-                "default": "IS_HTTPS_ENABLED",
-                "required": [],
-                "title": "name",
-                "type": "string"
-              },
-              "value": {
-                "default": "false",
-                "required": [],
-                "title": "value",
-                "type": "string"
-              }
-            },
             "required": [
               "name",
-              "value"
-            ],
-            "type": "object"
+              "valueFrom"
+            ]
           }
         ],
-        "required": []
+        "properties": {
+          "name": {
+            "required": [],
+            "type": "string"
+          },
+          "value": {
+            "required": [],
+            "type": "string"
+          },
+          "valueFrom": {
+            "oneOf": [
+              {
+                "required": [
+                  "configMapKeyRef"
+                ]
+              },
+              {
+                "required": [
+                  "secretKeyRef"
+                ]
+              }
+            ],
+            "properties": {
+              "configMapKeyRef": {
+                "properties": {
+                  "key": {
+                    "required": [],
+                    "type": "string"
+                  },
+                  "name": {
+                    "required": [],
+                    "type": "string"
+                  },
+                  "optional": {
+                    "required": [],
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "key",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "secretKeyRef": {
+                "properties": {
+                  "key": {
+                    "required": [],
+                    "type": "string"
+                  },
+                  "name": {
+                    "required": [],
+                    "type": "string"
+                  },
+                  "optional": {
+                    "required": [],
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "key",
+                  "name"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [],
+            "type": "object"
+          }
+        },
+        "required": [],
+        "type": "object"
       },
       "required": [],
       "title": "env",
@@ -567,7 +608,6 @@
     "nodeSelector",
     "tolerations",
     "affinity",
-    "env",
     "mariadb",
     "mysql",
     "postgresql",

--- a/charts/shlink-backend/values.yaml
+++ b/charts/shlink-backend/values.yaml
@@ -99,7 +99,46 @@ tolerations: []
 # -- Affinity settings for pod assignment
 affinity: {}
 
-# see https://shlink.io/documentation/environment-variables/ for a complete list
+# @schema
+# type: array
+# items:
+#   type: object
+#   properties:
+#     name:
+#       type: string
+#     value:
+#       type: string
+#     valueFrom:
+#       type: object
+#       oneOf:
+#         - required: ["configMapKeyRef"]
+#         - required: ["secretKeyRef"]
+#       properties:
+#         configMapKeyRef:
+#           type: object
+#           required: ["key", "name"]
+#           properties:
+#             key:
+#               type: string
+#             name:
+#               type: string
+#             optional:
+#               type: boolean
+#         secretKeyRef:
+#           type: object
+#           required: ["key", "name"]
+#           properties:
+#             key:
+#               type: string
+#             name:
+#               type: string
+#             optional:
+#               type: boolean
+#   oneOf:
+#     - required: ["name", "value"]
+#     - required: ["name", "valueFrom"]
+# @schema
+# -- Environment variables. Supports both direct values and references to ConfigMaps/Secrets. See https://shlink.io/documentation/environment-variables/ for a complete list
 env:
   - name: DEFAULT_DOMAIN
     value: doma.in


### PR DESCRIPTION
Adding the proper annotation to tell `helm-schema` to generate a schema that allows using configmaps or secrets as an environment variable value. Tested this locally and it fixes the issue I've had with the last two chart versions.