### PR TITLE
feat(shlink-backend): support external database config

### DIFF
--- a/charts/shlink-backend/CHANGELOG.md
+++ b/charts/shlink-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # shlink-backend
 
+## 4.5.6
+
+### Added
+
+- Option to configure an external database
+
 ## 4.5.5
 
 ### Added

--- a/charts/shlink-backend/Chart.yaml
+++ b/charts/shlink-backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: shlink-backend
 description: A PHP-based self-hosted URL shortener that can be used to serve shortened URLs under your own domain.
 type: application
-version: 4.5.5
+version: 4.5.6
 appVersion: "3.7.4"
 home: https://github.com/christianhuth/helm-charts
 icon: https://shlink.io/images/shlink-logo-blue.svg
@@ -36,7 +36,7 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: Changelog
+      description: Option to configure an external database
   artifacthub.io/signKey: |
     fingerprint: EE24F8BB6D099E78FD704F83B5ECDBCDDD485D0E
     url: https://charts.christianhuth.de/public.key

--- a/charts/shlink-backend/README.md
+++ b/charts/shlink-backend/README.md
@@ -55,6 +55,14 @@ The command removes all the Kubernetes components associated with the chart and 
 | env[0].value | string | `"doma.in"` |  |
 | env[1].name | string | `"IS_HTTPS_ENABLED"` |  |
 | env[1].value | string | `"false"` |  |
+| externalDatabase.database | string | `"shlink"` | Database name |
+| externalDatabase.driver | string | `"postgres"` | Driver of the external database |
+| externalDatabase.externalSecretKey | string | `""` | Key in the secret containing the database password |
+| externalDatabase.externalSecretName | string | `""` | Secret name containing the database password |
+| externalDatabase.host | string | `""` | Hostname of the external database |
+| externalDatabase.password | string | `"shlink"` | Database password |
+| externalDatabase.port | int | `5432` | Port of the external database |
+| externalDatabase.username | string | `"shlink"` | Database username |
 | fullnameOverride | string | `""` | String to fully override `"shlink-backend.fullname"` |
 | image.pullPolicy | string | `"Always"` | image pull policy |
 | image.repository | string | `"shlinkio/shlink"` | image repository |

--- a/charts/shlink-backend/templates/deployment.yaml
+++ b/charts/shlink-backend/templates/deployment.yaml
@@ -94,6 +94,28 @@ spec:
                   name: {{ template "postgresql.v1.secretName" .Subcharts.postgresql }}
                   key: {{ template "postgresql.v1.userPasswordKey" .Subcharts.postgresql }}
             {{- end }}
+            {{- if .Values.externalDatabase.host }}
+            - name: DB_DRIVER
+              value: {{ .Values.externalDatabase.driver }}
+            - name: DB_HOST
+              value: {{ .Values.externalDatabase.host }}
+            - name: DB_PORT
+              value: {{ .Values.externalDatabase.port | quote }}
+            - name: DB_NAME
+              value: {{ .Values.externalDatabase.database }}
+            - name: DB_USER
+              value: {{ .Values.externalDatabase.username }}
+            {{- if .Values.externalDatabase.externalSecretName }}
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalDatabase.externalSecretName }}
+                  key: {{ .Values.externalDatabase.externalSecretKey }}
+            {{- else }}
+            - name: DB_PASSWORD
+              value: {{ .Values.externalDatabase.password }}
+            {{- end }}
+            {{- end }}
             # RabbitMQ Settings
             {{- if .Values.rabbitmq.enabled }}
             - name: RABBITMQ_ENABLED

--- a/charts/shlink-backend/values.schema.json
+++ b/charts/shlink-backend/values.schema.json
@@ -96,6 +96,78 @@
       "title": "env",
       "type": "array"
     },
+    "externalDatabase": {
+      "properties": {
+        "database": {
+          "default": "shlink",
+          "description": "Database name",
+          "required": [],
+          "title": "database",
+          "type": "string"
+        },
+        "driver": {
+          "default": "postgres",
+          "description": "Driver of the external database",
+          "required": [],
+          "title": "driver",
+          "type": "string"
+        },
+        "externalSecretKey": {
+          "default": "",
+          "description": "Key in the secret containing the database password",
+          "required": [],
+          "title": "externalSecretKey",
+          "type": "string"
+        },
+        "externalSecretName": {
+          "default": "",
+          "description": "Secret name containing the database password",
+          "required": [],
+          "title": "externalSecretName",
+          "type": "string"
+        },
+        "host": {
+          "default": "",
+          "description": "Hostname of the external database",
+          "required": [],
+          "title": "host",
+          "type": "string"
+        },
+        "password": {
+          "default": "shlink",
+          "description": "Database password",
+          "required": [],
+          "title": "password",
+          "type": "string"
+        },
+        "port": {
+          "default": 5432,
+          "description": "Port of the external database",
+          "required": [],
+          "title": "port",
+          "type": "integer"
+        },
+        "username": {
+          "default": "shlink",
+          "description": "Database username",
+          "required": [],
+          "title": "username",
+          "type": "string"
+        }
+      },
+      "required": [
+        "driver",
+        "host",
+        "port",
+        "database",
+        "username",
+        "password",
+        "externalSecretName",
+        "externalSecretKey"
+      ],
+      "title": "externalDatabase",
+      "type": "object"
+    },
     "fullnameOverride": {
       "default": "",
       "description": "String to fully override `\"shlink-backend.fullname\"`",
@@ -571,6 +643,7 @@
     "mariadb",
     "mysql",
     "postgresql",
+    "externalDatabase",
     "rabbitmq",
     "redis"
   ],

--- a/charts/shlink-backend/values.yaml
+++ b/charts/shlink-backend/values.yaml
@@ -127,6 +127,24 @@ postgresql:
     password: shlink
     username: shlink
 
+externalDatabase:
+  # -- Driver of the external database
+  driver: postgres
+  # -- Hostname of the external database
+  host: ""
+  # -- Port of the external database
+  port: 5432
+  # -- Database name
+  database: shlink
+  # -- Database username
+  username: shlink
+  # -- Database password
+  password: shlink
+  # -- Secret name containing the database password
+  externalSecretName: ""
+  # -- Key in the secret containing the database password
+  externalSecretKey: ""
+
 rabbitmq:
   enabled: false
 


### PR DESCRIPTION
Hi @christianhuth,

This PR adds support to configure an `externalDatabase` for the shlink backend.
I wasn't sure if I should add a `externalDatabase.enabled` value or configure the external database if the `externalDatabase.host` value is set. Which option do you prefer?

