### PR TITLE
feat(shlink-web): support environment variables

### DIFF
--- a/charts/shlink-web/CHANGELOG.md
+++ b/charts/shlink-web/CHANGELOG.md
@@ -1,5 +1,11 @@
 # shlink-web
 
+## 1.3.2
+
+### Added
+
+- Option to configure environment variables
+
 ## 1.3.1
 
 ### Added

--- a/charts/shlink-web/Chart.yaml
+++ b/charts/shlink-web/Chart.yaml
@@ -15,7 +15,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: Option to configure environment variables
+      description: Option to add additional environment variables (extraEnv)
   artifacthub.io/screenshots: |
     - title: Add a new link that should be shortened.
       url: https://alejandrocelaya.blog/assets/img/shlink-web-client-3/creation-form-after.png

--- a/charts/shlink-web/Chart.yaml
+++ b/charts/shlink-web/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: shlink-web
 description: A  ReactJS-based progressive web application for Shlink.
 type: application
-version: 1.3.1
+version: 1.3.2
 appVersion: "4.3.0"
 home: https://github.com/christianhuth/helm-charts
 icon: https://shlink.io/images/shlink-logo-blue.svg
@@ -15,7 +15,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: Changelog
+      description: Option to configure environment variables
   artifacthub.io/screenshots: |
     - title: Add a new link that should be shortened.
       url: https://alejandrocelaya.blog/assets/img/shlink-web-client-3/creation-form-after.png

--- a/charts/shlink-web/README.md
+++ b/charts/shlink-web/README.md
@@ -52,6 +52,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | configuration | list | `[]` |  |
+| env | list | `[]` | Environment variables. Supports both direct values and references to ConfigMaps/Secrets. See https://shlink.io/documentation/shlink-web-client/pre-configuring-servers/ for the supported variables. |
 | fullnameOverride | string | `""` | String to fully override `"shlink-web.fullname"` |
 | image.pullPolicy | string | `"Always"` | image pull policy |
 | image.repository | string | `"shlinkio/shlink-web-client"` | image repository |

--- a/charts/shlink-web/templates/deployment.yaml
+++ b/charts/shlink-web/templates/deployment.yaml
@@ -38,6 +38,10 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.env }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/charts/shlink-web/values.schema.json
+++ b/charts/shlink-web/values.schema.json
@@ -51,6 +51,100 @@
       "title": "configuration",
       "type": "array"
     },
+    "env": {
+      "description": "Environment variables. Supports both direct values and references to ConfigMaps/Secrets. See https://shlink.io/documentation/shlink-web-client/pre-configuring-servers/ for the supported variables.",
+      "items": {
+        "oneOf": [
+          {
+            "required": [
+              "name",
+              "value"
+            ]
+          },
+          {
+            "required": [
+              "name",
+              "valueFrom"
+            ]
+          }
+        ],
+        "properties": {
+          "name": {
+            "required": [],
+            "type": "string"
+          },
+          "value": {
+            "required": [],
+            "type": "string"
+          },
+          "valueFrom": {
+            "oneOf": [
+              {
+                "required": [
+                  "configMapKeyRef"
+                ]
+              },
+              {
+                "required": [
+                  "secretKeyRef"
+                ]
+              }
+            ],
+            "properties": {
+              "configMapKeyRef": {
+                "properties": {
+                  "key": {
+                    "required": [],
+                    "type": "string"
+                  },
+                  "name": {
+                    "required": [],
+                    "type": "string"
+                  },
+                  "optional": {
+                    "required": [],
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "key",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "secretKeyRef": {
+                "properties": {
+                  "key": {
+                    "required": [],
+                    "type": "string"
+                  },
+                  "name": {
+                    "required": [],
+                    "type": "string"
+                  },
+                  "optional": {
+                    "required": [],
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "key",
+                  "name"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [],
+            "type": "object"
+          }
+        },
+        "required": [],
+        "type": "object"
+      },
+      "required": [],
+      "title": "env",
+      "type": "array"
+    },
     "fullnameOverride": {
       "default": "",
       "description": "String to fully override `\"shlink-web.fullname\"`",

--- a/charts/shlink-web/values.yaml
+++ b/charts/shlink-web/values.yaml
@@ -106,3 +106,45 @@ configuration: []
   # - name: "Main server"
   #   url: "https://doma.in"
   #   apiKey: "09c972b7-506b-49f1-a19a-d729e22e599c"
+
+# @schema
+# type: array
+# items:
+#   type: object
+#   properties:
+#     name:
+#       type: string
+#     value:
+#       type: string
+#     valueFrom:
+#       type: object
+#       oneOf:
+#         - required: ["configMapKeyRef"]
+#         - required: ["secretKeyRef"]
+#       properties:
+#         configMapKeyRef:
+#           type: object
+#           required: ["key", "name"]
+#           properties:
+#             key:
+#               type: string
+#             name:
+#               type: string
+#             optional:
+#               type: boolean
+#         secretKeyRef:
+#           type: object
+#           required: ["key", "name"]
+#           properties:
+#             key:
+#               type: string
+#             name:
+#               type: string
+#             optional:
+#               type: boolean
+#   oneOf:
+#     - required: ["name", "value"]
+#     - required: ["name", "valueFrom"]
+# @schema
+# -- Environment variables. Supports both direct values and references to ConfigMaps/Secrets. See https://shlink.io/documentation/shlink-web-client/pre-configuring-servers/ for the supported variables.
+env: []

--- a/charts/shlink-web/values.yaml
+++ b/charts/shlink-web/values.yaml
@@ -107,44 +107,5 @@ configuration: []
   #   url: "https://doma.in"
   #   apiKey: "09c972b7-506b-49f1-a19a-d729e22e599c"
 
-# @schema
-# type: array
-# items:
-#   type: object
-#   properties:
-#     name:
-#       type: string
-#     value:
-#       type: string
-#     valueFrom:
-#       type: object
-#       oneOf:
-#         - required: ["configMapKeyRef"]
-#         - required: ["secretKeyRef"]
-#       properties:
-#         configMapKeyRef:
-#           type: object
-#           required: ["key", "name"]
-#           properties:
-#             key:
-#               type: string
-#             name:
-#               type: string
-#             optional:
-#               type: boolean
-#         secretKeyRef:
-#           type: object
-#           required: ["key", "name"]
-#           properties:
-#             key:
-#               type: string
-#             name:
-#               type: string
-#             optional:
-#               type: boolean
-#   oneOf:
-#     - required: ["name", "value"]
-#     - required: ["name", "valueFrom"]
-# @schema
-# -- Environment variables. Supports both direct values and references to ConfigMaps/Secrets. See https://shlink.io/documentation/shlink-web-client/pre-configuring-servers/ for the supported variables.
-env: []
+# -- additional environment variables to be added to the pods. See https://shlink.io/documentation/shlink-web-client/pre-configuring-servers for the supported variables.
+extraEnv: []


### PR DESCRIPTION
Hi,

This PR adds an option to pass environment variables to the `shlink-web` service.