### PR TITLE
use oci based helm repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,7 @@ body:
     attributes:
       value: |
         Thanks for taking the time to fill out this bug report! Please be cautious with the sensitive information/logs while filing the issue.
- 
+
   - id: chart-name
     type: dropdown
     attributes:

--- a/charts/headwind-mdm/CHANGELOG.md
+++ b/charts/headwind-mdm/CHANGELOG.md
@@ -1,7 +1,7 @@
 # headwind-mdm
 
-## 3.0.2
+## 3.0.3
 
 ### Changed
 
-- dependency to postgresql to 16.4.9
+- use OCI based Bitnami Helm Repositories

--- a/charts/headwind-mdm/Chart.yaml
+++ b/charts/headwind-mdm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: headwind-mdm
 description: Headwind MDM - an open source mobile device management software for Android
 type: application
-version: 3.0.2
+version: 3.0.3
 appVersion: "0.1.5"
 home: https://github.com/christianhuth/helm-charts
 icon: https://h-mdm.com/wp-content/uploads/2019/07/neew-logo.png
@@ -15,13 +15,13 @@ sources:
   - https://hub.docker.com/r/headwindmdm/hmdm
 dependencies:
   - name: postgresql
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 16.4.9
     condition: postgresql.enabled
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: dependency to postgresql to 16.4.9
+      description: use OCI based Bitnami Helm Repositories
   artifacthub.io/screenshots: |
     - title: Headwind MDM is a powerful Open Source platform to manage your Enterprise Android Devices.
       url: https://images.wondershare.com/drfone/article/2022/11/opensource-mdm-3.jpg

--- a/charts/kube-ops-view/CHANGELOG.md
+++ b/charts/kube-ops-view/CHANGELOG.md
@@ -1,7 +1,7 @@
 # kube-ops-view
 
-## 4.1.1
+## 4.1.2
 
 ### Changed
 
-- dependency to redis to 20.7.1
+- use OCI based Bitnami Helm Repositories

--- a/charts/kube-ops-view/Chart.yaml
+++ b/charts/kube-ops-view/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: kube-ops-view
 description: A Helm chart for bootstrapping kube-ops-view.
 type: application
-version: 4.1.1
+version: 4.1.2
 appVersion: "23.5.0"
 home: https://github.com/christianhuth/helm-charts
 icon: https://codeberg.org/repo-avatars/677-c51f6426305941cab515fdd98368f0bb
@@ -14,14 +14,14 @@ sources:
   - https://codeberg.org/hjacobs/kube-ops-view
 dependencies:
   - name: redis
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 20.7.1
     condition: redis.enabled
 annotations:
   artifacthub.io/category: monitoring-logging
   artifacthub.io/changes: |
     - kind: changed
-      description: dependency to redis to 20.7.1
+      description: use OCI based Bitnami Helm Repositories
   artifacthub.io/screenshots: |
     - title: Dashboard overview of a Kubernetes cluster
       url: https://codeberg.org/hjacobs/kube-ops-view/media/branch/main/screenshot.png

--- a/charts/polr/CHANGELOG.md
+++ b/charts/polr/CHANGELOG.md
@@ -1,7 +1,7 @@
 # polr
 
-## 2.0.1
+## 2.0.2
 
-### Fixed
+### Changed
 
-- changelog
+- use OCI based Bitnami Helm Repositories

--- a/charts/polr/Chart.yaml
+++ b/charts/polr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: polr
 description: Polr is a quick, modern, and open-source link shortener
 type: application
-version: 2.0.1
+version: 2.0.2
 appVersion: "2.3.0"
 home: https://github.com/christianhuth/helm-charts
 icon: http://docs.polrproject.org/en/latest/logo.png
@@ -14,12 +14,12 @@ sources:
   - https://github.com/ajanvier/docker-polr
 dependencies:
   - name: mysql
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 12.2.2
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: changelog
+    - kind: changed
+      description: use OCI based Bitnami Helm Repositories
   artifacthub.io/screenshots: |
     - title: Polr converts some long links into shorter ones.
       url: https://selfhostedweb.org/wp-content/uploads/2017/02/shortit-1024x346.png


### PR DESCRIPTION
#### What this PR does / why we need it

Changes the Helm Repository URL for Bitnami dependencies to the new oci based URL.

#### Which issue this PR fixes

- fixes #1283 

#### Checklist

- [x] Chart Version bumped