### PR TITLE
Remove grouping of Merge Requests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,9 +11,8 @@
   "packageRules": [
     {
       "matchFileNames": ["charts/passbolt-ha/Chart.yaml"],
-      "groupName": "Updates for chart passbolt-ha",
       "postUpgradeTasks": {
-        "commands": ["./renovate-update-chart.sh 'passbolt-ha' {{updateType}} {{depName}} {{newValue}}"],
+        "commands": ["bash ./renovate-update-chart.sh 'passbolt-ha' '{{{updateType}}}' '{{{depName}}}' '{{{newValue}}}'"],
         "executionMode": "branch"
       }
     }


### PR DESCRIPTION
This doesn't work as expected if multiple dependencies are updated at once. Variables like updateType contain only the first value and not an "aggregated" one.

<!--
Thank you for contributing to this repository.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/christianhuth/helm-charts/tree/pr-template?tab=readme-ov-file#development
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Target a branch starting with `dev-`
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[baserow]`)
