### PR TITLE
squest: allow defining additional volumeMounts for the squest nginx and init container

### DIFF
--- a/charts/squest/CHANGELOG.md
+++ b/charts/squest/CHANGELOG.md
@@ -1,7 +1,7 @@
 # squest
 
-## 1.2.0
+## 1.2.1
 
 ### Added
 
-- allow defining additional volumeMounts for squest, celery-beat and celery-worker pods
+- allow defining additional volumeMounts for the squest init and nginx container

--- a/charts/squest/Chart.yaml
+++ b/charts/squest/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: squest
 description: Squest is a self-service portal that works on top of Red Hat Ansible Automation Platform/AWX.
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: "2.7.0"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/squest/icon.svg
@@ -28,7 +28,7 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: allow defining additional volumeMounts for squest, celery-beat and celery-worker pods
+      description: allow defining additional volumeMounts for the squest nginx and init container
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/squest/templates/squest/deployment.yaml
+++ b/charts/squest/templates/squest/deployment.yaml
@@ -268,6 +268,11 @@ spec:
             - name: media
               mountPath: /app/media
               readOnly: true
+            {{- if .Values.squest.nginx.extraVolumeMounts }}
+            {{- with .Values.squest.nginx.extraVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- end }}
       restartPolicy: Always
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/squest/templates/squest/deployment.yaml
+++ b/charts/squest/templates/squest/deployment.yaml
@@ -89,6 +89,11 @@ spec:
           volumeMounts:
             - mountPath: /app/static
               name: static
+          {{- if .Values.squest.init.extraVolumeMounts }}
+          {{- with .Values.squest.init.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
 
       containers:
         - name: squest

--- a/charts/squest/values.yaml
+++ b/charts/squest/values.yaml
@@ -213,6 +213,11 @@ squest:
     # -- additional volumeMounts to be added to the nginx container
     extraVolumeMounts: []
 
+  init:
+
+    # -- additional volumeMounts to be added to the init container
+    extraVolumeMounts: []
+
 celery:
 
   beat:

--- a/charts/squest/values.yaml
+++ b/charts/squest/values.yaml
@@ -210,6 +210,9 @@ squest:
       # -- Overrides the image tag
       tag: "1.28.0-alpine"
 
+    # -- additional volumeMounts to be added to the nginx container
+    extraVolumeMounts: []
+
 celery:
 
   beat:

--- a/charts/squest/values.yaml
+++ b/charts/squest/values.yaml
@@ -107,10 +107,10 @@ squest:
   # -- Affinity settings for pod assignment
   affinity: {}
 
-  # -- additional volumes to be added to the pods
+  # -- additional volumes to be added to the squest pods
   extraVolumes: []
 
-  # -- additional volumeMounts to be added to the pods
+  # -- additional volumeMounts to be added to the squest container (nginx and init container have separate extraVolumeMounts)
   extraVolumeMounts: []
 
   # -- additional environment variables to be added to the pods. See https://hewlettpackard.github.io/squest/latest/configuration/squest_settings for a complete list.


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

#1829 added functionality to add additional volume mounts to the pods. This PR enhances this so also the nginx and init containers can get additional volumes.

#### Checklist

- [ ] Target a branch starting with `dev-`
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[baserow]`)
