### PR TITLE
squest: remove readOnly option that annoys ArgoCD

### DIFF
--- a/charts/squest/CHANGELOG.md
+++ b/charts/squest/CHANGELOG.md
@@ -1,7 +1,7 @@
 # squest
 
-## 1.2.1
+## 1.2.2
 
 ### Added
 
-- allow defining additional volumeMounts for the squest nginx and init container
+- remove readOnly option from PVC that annoys ArgoCD

--- a/charts/squest/Chart.yaml
+++ b/charts/squest/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: squest
 description: Squest is a self-service portal that works on top of Red Hat Ansible Automation Platform/AWX.
 type: application
-version: 1.2.1
+version: 1.2.2
 appVersion: "2.7.0"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/squest/icon.svg
@@ -28,7 +28,7 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: allow defining additional volumeMounts for the squest nginx and init container
+      description: remove readOnly option from PVC that annoys ArgoCD
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/squest/templates/squest/deployment.yaml
+++ b/charts/squest/templates/squest/deployment.yaml
@@ -302,7 +302,6 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "squest.squest.fullname" . }}-media
         - name: static
-          readOnly: true
           persistentVolumeClaim:
             claimName: {{ include "squest.squest.fullname" . }}-static
         {{- if .Values.squest.extraVolumes }}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

The `readOnly: true`, set on the `static` PVC, annoys ArgoCD and the deployment always shows as "out of sync".

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Target a branch starting with `dev-`
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[baserow]`)
