### PR TITLE
squest: make podSecurityContext.fsGroup not required

### DIFF
--- a/charts/squest/CHANGELOG.md
+++ b/charts/squest/CHANGELOG.md
@@ -1,7 +1,7 @@
 # squest
 
-## 1.2.2
+## 1.2.3
 
-### Added
+### Changed
 
-- remove readOnly option from PVC that annoys ArgoCD
+- also make podsecurity.fsGroup not required

--- a/charts/squest/Chart.yaml
+++ b/charts/squest/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: squest
 description: Squest is a self-service portal that works on top of Red Hat Ansible Automation Platform/AWX.
 type: application
-version: 1.2.2
+version: 1.2.3
 appVersion: "2.7.0"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/squest/icon.svg
@@ -27,8 +27,8 @@ dependencies:
     condition: redis.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: remove readOnly option from PVC that annoys ArgoCD
+    - kind: changed
+      description: also make podsecurity.fsGroup not required
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/squest/values.yaml
+++ b/charts/squest/values.yaml
@@ -45,6 +45,9 @@ squest:
   # @schema
   # -- pod-level security context
   podSecurityContext:
+    # @schema
+    # required: false
+    # @schema
     fsGroup: 999
 
   # -- container-level security context


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

`podSecurityContext` is already not required, but `podSecurityContext.fsGroup` seems to be.

```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
squest:
- squest.podSecurityContext: fsGroup is required
```

Only setting `podSecurityContext` to `null` works, but throws a helm warning. Setting it to `{}` does throw the error above.

#### Checklist

- [ ] Target a branch starting with `dev-`
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[baserow]`)
