### PR TITLE
[squest]: Allow setting the update strategy for the squest deployment and change this to "Recreate"

### DIFF
--- a/charts/squest/CHANGELOG.md
+++ b/charts/squest/CHANGELOG.md
@@ -1,7 +1,7 @@
 # squest
 
-## 1.3.0
+## 1.3.2
 
 ### Added
 
-- allow setting envFrom to load environment variables from configMaps or secrets
+- use recreate strategy for the deployment due to the PVC

--- a/charts/squest/Chart.yaml
+++ b/charts/squest/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: squest
 description: Squest is a self-service portal that works on top of Red Hat Ansible Automation Platform/AWX.
 type: application
-version: 1.3.0
+version: 1.3.2
 appVersion: "2.7.0"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/squest/icon.svg
@@ -27,8 +27,8 @@ dependencies:
     condition: redis.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: allow setting envFrom to load environment variables from configMaps or secrets
+    - kind: changed
+      description: use recreate strategy for the deployment due to the PVC
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/squest/templates/squest/deployment.yaml
+++ b/charts/squest/templates/squest/deployment.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         {{- include "squest.squest.selectorLabels" . | nindent 8 }}
     spec:
+      strategy: {{ .Values.squest.strategy }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/squest/values.yaml
+++ b/charts/squest/values.yaml
@@ -19,6 +19,9 @@ squest:
     # -- Overrides the image tag
     tag: "2.7.1"
 
+  # -- Upgrade strategy For Deployments, valid values are Recreate (default) and RollingUpdate
+  strategy: Recreate
+
   # -- Number of replicas
   replicaCount: 1
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Change the update strategy for the deployment to `Recreate` due to issues with the PVC (in case this is not RWX), but allow overwriting this via the `values.yaml`.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Target a branch starting with `dev-`
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[baserow]`)
