### PR TITLE
[squest] really fix deployment recreate (#1899)

### DIFF
--- a/charts/squest/CHANGELOG.md
+++ b/charts/squest/CHANGELOG.md
@@ -1,7 +1,7 @@
 # squest
 
-## 1.3.3
+## 1.3.4
 
 ### Changed
 
-- fix deployment strategy syntax
+- really fix the deployment strategy syntax

--- a/charts/squest/Chart.yaml
+++ b/charts/squest/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: squest
 description: Squest is a self-service portal that works on top of Red Hat Ansible Automation Platform/AWX.
 type: application
-version: 1.3.3
+version: 1.3.4
 appVersion: "2.7.0"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/squest/icon.svg
@@ -28,7 +28,7 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: fix deployment strategy syntax
+      description: really fix the deployment strategy syntax
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/squest/templates/squest/deployment.yaml
+++ b/charts/squest/templates/squest/deployment.yaml
@@ -13,6 +13,8 @@ spec:
   selector:
     matchLabels:
       {{- include "squest.squest.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: {{ .Values.squest.strategy }}
   template:
     metadata:
       {{- with .Values.squest.podAnnotations }}
@@ -22,8 +24,6 @@ spec:
       labels:
         {{- include "squest.squest.selectorLabels" . | nindent 8 }}
     spec:
-      strategy:
-        type: {{ .Values.squest.strategy }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
* charts/squest/Chart.yaml: 1.3.4

* charts/squest/CHANGELOG.md: 1.3.4

* charts/squest/templates/squest/deployment.yaml: strategy is spec.strategy, not spec.template.spec.strategy... :-(

<!--
Thank you for contributing to this repository.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/christianhuth/helm-charts/tree/pr-template?tab=readme-ov-file#development
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Target a branch starting with `dev-`
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[baserow]`)
