### PR TITLE
[umami] Updated Umami to latest (2.18.1) (#1996)

### DIFF
--- a/charts/umami/CHANGELOG.md
+++ b/charts/umami/CHANGELOG.md
@@ -1,7 +1,7 @@
 # umami
 
-## 4.7.14
+## 4.8.0
 
 ### Changed
 
-- dependency of postgresql to 16.7.15
+- updated umami to 2.18.1

--- a/charts/umami/CHANGELOG.md
+++ b/charts/umami/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 ### Changed
 
-- updated umami to 2.18.1
+- app version to 2.18.1

--- a/charts/umami/Chart.yaml
+++ b/charts/umami/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: umami
 description: Umami is a simple, fast, privacy-focused alternative to Google Analytics.
 type: application
-version: 4.7.14
-appVersion: "v2.15.1"
+version: 4.8.0
+appVersion: "v2.18.1"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/umami/icon.svg
 maintainers:
@@ -26,7 +26,7 @@ annotations:
   artifacthub.io/category: monitoring-logging
   artifacthub.io/changes: |
     - kind: changed
-      description: dependency of postgresql to 16.7.15
+      description: app version to 2.18.1
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/umami/README.md
+++ b/charts/umami/README.md
@@ -67,7 +67,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | image.pullPolicy | string | `"Always"` | image pull policy |
 | image.registry | string | `"ghcr.io"` | image registry |
 | image.repository | string | `"umami-software/umami"` | image repository |
-| image.tag | string | `"postgresql-v2.15.1"` | Overrides the image tag |
+| image.tag | string | `"postgresql-v2.18.1"` | Overrides the image tag |
 | imagePullSecrets | list | `[]` | If defined, uses a Secret to pull an image from a private Docker registry or repository. |
 | ingress.annotations | object | `{}` | Additional annotations for the Ingress resource |
 | ingress.className | string | `""` | IngressClass that will be be used to implement the Ingress |

--- a/charts/umami/values.schema.json
+++ b/charts/umami/values.schema.json
@@ -190,7 +190,7 @@
           "type": "string"
         },
         "tag": {
-          "default": "postgresql-v2.15.1",
+          "default": "postgresql-v2.18.1",
           "description": "Overrides the image tag",
           "required": [],
           "title": "tag",

--- a/charts/umami/values.yaml
+++ b/charts/umami/values.yaml
@@ -12,7 +12,7 @@ image:
   # -- image pull policy
   pullPolicy: Always
   # -- Overrides the image tag
-  tag: "postgresql-v2.15.1"
+  tag: "postgresql-v2.18.1"
 
 # -- If defined, uses a Secret to pull an image from a private Docker registry or repository.
 imagePullSecrets: []


### PR DESCRIPTION
#### Checklist

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[baserow]`)
