### PR TITLE
[github-exporter] fix path to private key

### DIFF
--- a/charts/github-exporter/CHANGELOG.md
+++ b/charts/github-exporter/CHANGELOG.md
@@ -1,5 +1,7 @@
 # github-exporter
-
+## 1.0.4
+### Fixed
+- [Incorrect path to GitHub App private key](https://github.com/christianhuth/helm-charts/issues/2205)
 ## 1.0.3
 
 ### Changed

--- a/charts/github-exporter/Chart.yaml
+++ b/charts/github-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: github-exporter
 description: A Helm Chart for the GitHub Prometheus Exporter
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: "1.3.1"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/github-exporter/icon.svg

--- a/charts/github-exporter/templates/deployment.yaml
+++ b/charts/github-exporter/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
                   name: {{ include "github-exporter.auth.secretName" . | quote }}
                   key: github-app-installation-id
             - name: GITHUB_APP_KEY_PATH
-              value: /tmp/key.pem
+              value: /tmp/github-app-private-key
             {{- end }}
             {{- if .Values.github.auth.token.enabled }}
             - name: GITHUB_TOKEN


### PR DESCRIPTION
#### What this PR does / why we need it
This fixes the path to the GitHub App private key

#### Which issue this PR fixes
- Fixes #2205

#### Special notes for your reviewer

#### Checklist

- [ ] Target a branch starting with `dev-`
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[baserow]`)
