### PR TITLE
[umami] Defined startup probe on Umami chart

### DIFF
--- a/charts/umami/Chart.yaml
+++ b/charts/umami/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: umami
 description: Umami is a simple, fast, privacy-focused alternative to Google Analytics.
 type: application
-version: 7.3.0
+version: 7.3.1
 appVersion: "v2.20.1"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/umami/icon.svg

--- a/charts/umami/templates/deployment.yaml
+++ b/charts/umami/templates/deployment.yaml
@@ -122,6 +122,12 @@ spec:
             httpGet:
               path: /
               port: http
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

During the initial installation of Umami, the PostgreSQL ORM schema migration must not take longer than the liveness probe timeout defined in the chart. Otherwise, the pod will be deleted during migration, breaking the app deployment and requiring manual action to drop the database.

Setting up a startup probe on the Kubernetes deployment ensures that the migration is finished before the application and the liveness/readiness probes run.

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[baserow]`)
