### PR TITLE
Add Claude Code settings to .gitignore

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git -C /home/christianhuth/code/k8s/helm-charts pull:*)",
+      "Bash(git -C /home/christianhuth/code/k8s/helm-charts checkout main)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,8 @@ charts/**/Chart.lock
 # Support for Project snippet scope
 !.vscode/*.code-snippets
 
+### Claude Code ###
+# Ignore local settings (personal/machine-specific)
+.claude/settings.local.json
+
 # End of https://www.toptal.com/developers/gitignore/api/helm,visualstudiocode


### PR DESCRIPTION
## Summary
- Add `.claude/settings.local.json` to `.gitignore` to exclude personal machine-specific settings
- Include `.claude/settings.json` for shared team configuration

## Test plan
- [x] Verify `.gitignore` syntax is correct
- [ ] Confirm CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)