### PR TITLE
[Baserow] - add timeoutSeconds to liveness and readiness probes in frontend deployment

### DIFF
--- a/charts/baserow/templates/frontend/frontend-deployment.yaml
+++ b/charts/baserow/templates/frontend/frontend-deployment.yaml
@@ -59,6 +59,7 @@ spec:
             initialDelaySeconds: {{ .Values.frontend.livenessProbe.initialDelaySeconds | int }}
             periodSeconds: {{ .Values.frontend.livenessProbe.periodSeconds | int }}
             successThreshold: {{ .Values.frontend.livenessProbe.successThreshold | int }}
+            timeoutSeconds: {{ .Values.frontend.livenessProbe.timeoutSeconds | int }}
           readinessProbe:
             httpGet:
               path: /_health/
@@ -66,6 +67,7 @@ spec:
             initialDelaySeconds: {{ .Values.frontend.readinessProbe.initialDelaySeconds | int }}
             periodSeconds: {{ .Values.frontend.readinessProbe.periodSeconds | int }}
             successThreshold: {{ .Values.frontend.readinessProbe.successThreshold | int }}
+            timeoutSeconds: {{ .Values.frontend.readinessProbe.timeoutSeconds | int }}
           {{- with .Values.frontend.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/baserow/values.yaml
+++ b/charts/baserow/values.yaml
@@ -158,6 +158,8 @@ frontend:
     periodSeconds: 5
     # -- Success threshold for livenessProbe
     successThreshold: 1
+    # -- Timeout seconds for livenessProbe
+    timeoutSeconds: 1
 
   readinessProbe:
     # -- Initial delay seconds for readinessProbe
@@ -166,6 +168,8 @@ frontend:
     periodSeconds: 5
     # -- Success threshold for readinessProbe
     successThreshold: 1
+    # -- Timeout seconds for readinessProbe
+    timeoutSeconds: 1
 
   # -- Node labels for pod assignment
   nodeSelector: {}


### PR DESCRIPTION
<!--
Thank you for contributing to this repository.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/christianhuth/helm-charts/tree/main?tab=readme-ov-file#development
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Adds the timeoutSeconds field to the livenessProbe and readinessProbe settings of the frontend deployment.This allows users to configure the probe wait time, preventing the pod from being unnecessarily restarted in slower environments where the response may take a little longer than the default 1 second. This came about because in my environment I needed to run a patch directly on the deployment to edit this field, and after editing my problem was solved.


#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer
- I kept the default value in the values ​​section, which is currently 1 second, but I believe something closer to 5 seconds would be even more interesting. I'm open to suggestions.
- I couldn't find the dev branch.
#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Target a branch starting with `dev-`
- [x ] Chart Version bumped
- [x ] Title of the PR starts with chart name (e.g. `[baserow]`)
