### PR TITLE
[all-charts] add timeouts to routes

### DIFF
--- a/charts/audiobookshelf/CHANGELOG.md
+++ b/charts/audiobookshelf/CHANGELOG.md
@@ -1,7 +1,7 @@
 # audiobookshelf
 
-## 2.0.1
+## 2.1.0
 
-### Changed
+### Added
 
-- App Version to 2.33.2
+- option to define route timeouts

--- a/charts/audiobookshelf/Chart.yaml
+++ b/charts/audiobookshelf/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: audiobookshelf
 description: A Helm chart for installing the Argo CD Metrics Server, which connects to Prometheus and can be used to display Metrics in the Argo CD UI
 type: application
-version: 2.0.1
+version: 2.1.0
 appVersion: "2.33.2"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/audiobookshelf/icon.svg
@@ -13,8 +13,8 @@ sources:
   - https://github.com/argoproj-labs/argocd-extension-metrics
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: App Version to 2.33.2
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/audiobookshelf/README.md
+++ b/charts/audiobookshelf/README.md
@@ -120,6 +120,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | see [values.yaml](./values.yaml) | container-level security context |
 | service.port | int | `8080` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/audiobookshelf/templates/route.yaml
+++ b/charts/audiobookshelf/templates/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/audiobookshelf/values.schema.json
+++ b/charts/audiobookshelf/values.schema.json
@@ -769,6 +769,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -782,7 +788,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/audiobookshelf/values.yaml
+++ b/charts/audiobookshelf/values.yaml
@@ -124,6 +124,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: true

--- a/charts/baserow/CHANGELOG.md
+++ b/charts/baserow/CHANGELOG.md
@@ -1,7 +1,7 @@
 # baserow
 
-## 7.2.2
+## 7.3.0
 
-### Changed
+### Added
 
-- dependency of postgresql to 18.6.2
+- option to define route timeouts

--- a/charts/baserow/Chart.yaml
+++ b/charts/baserow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: baserow
 description: Baserow is an open source no-code database and Airtable alternative.
 type: application
-version: 7.2.2
+version: 7.3.0
 appVersion: "2.0.6"
 home: https://github.com/christianknell/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/baserow/icon.svg
@@ -24,8 +24,8 @@ dependencies:
 annotations:
   artifacthub.io/category: database
   artifacthub.io/changes: |
-    - kind: changed
-      description: dependency of postgresql to 18.6.2
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/baserow/README.md
+++ b/charts/baserow/README.md
@@ -88,6 +88,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | backend.asgi.route.main.labels | object | `{}` | Add labels to the route |
 | backend.asgi.route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | backend.asgi.route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| backend.asgi.route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | backend.asgi.securityContext | object | `{"runAsGroup":9999,"runAsNonRoot":true,"runAsUser":9999}` | container-level security context |
 | backend.asgi.selectorLabels | object | `{}` | Additional labels to add to the pod |
 | backend.asgi.service.port | int | `8000` | Kubernetes port where service is exposed |
@@ -244,6 +245,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | backend.wsgi.route.main.labels | object | `{}` | Add labels to the route |
 | backend.wsgi.route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | backend.wsgi.route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| backend.wsgi.route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | backend.wsgi.securityContext | object | `{"runAsGroup":9999,"runAsNonRoot":true,"runAsUser":9999}` | container-level security context |
 | backend.wsgi.selectorLabels | object | `{}` | Additional labels to add to the pod |
 | backend.wsgi.service.port | int | `8000` | Kubernetes port where service is exposed |
@@ -319,6 +321,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | frontend.route.main.labels | object | `{}` | Add labels to the route |
 | frontend.route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | frontend.route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| frontend.route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | frontend.securityContext | object | `{"runAsGroup":9999,"runAsNonRoot":true,"runAsUser":9999}` | container-level security context |
 | frontend.selectorLabels | object | `{}` | Additional labels to add to the pod |
 | frontend.service.port | int | `3000` | Kubernetes port where service is exposed |

--- a/charts/baserow/templates/asgi/asgi-route.yaml
+++ b/charts/baserow/templates/asgi/asgi-route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/baserow/templates/frontend/frontend-route.yaml
+++ b/charts/baserow/templates/frontend/frontend-route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/baserow/templates/wsgi/wsgi-route.yaml
+++ b/charts/baserow/templates/wsgi/wsgi-route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/baserow/values.schema.json
+++ b/charts/baserow/values.schema.json
@@ -365,6 +365,12 @@
                       },
                       "title": "parentRefs",
                       "type": "array"
+                    },
+                    "timeouts": {
+                      "description": "defines the timeouts that can be configured for an HTTP request",
+                      "required": [],
+                      "title": "timeouts",
+                      "type": "object"
                     }
                   },
                   "required": [
@@ -378,7 +384,8 @@
                     "matches",
                     "filters",
                     "additionalRules",
-                    "httpsRedirect"
+                    "httpsRedirect",
+                    "timeouts"
                   ],
                   "title": "main",
                   "type": "object"
@@ -1842,6 +1849,12 @@
                       },
                       "title": "parentRefs",
                       "type": "array"
+                    },
+                    "timeouts": {
+                      "description": "defines the timeouts that can be configured for an HTTP request",
+                      "required": [],
+                      "title": "timeouts",
+                      "type": "object"
                     }
                   },
                   "required": [
@@ -1855,7 +1868,8 @@
                     "matches",
                     "filters",
                     "additionalRules",
-                    "httpsRedirect"
+                    "httpsRedirect",
+                    "timeouts"
                   ],
                   "title": "main",
                   "type": "object"
@@ -2610,6 +2624,12 @@
                   },
                   "title": "parentRefs",
                   "type": "array"
+                },
+                "timeouts": {
+                  "description": "defines the timeouts that can be configured for an HTTP request",
+                  "required": [],
+                  "title": "timeouts",
+                  "type": "object"
                 }
               },
               "required": [
@@ -2623,7 +2643,8 @@
                 "matches",
                 "filters",
                 "additionalRules",
-                "httpsRedirect"
+                "httpsRedirect",
+                "timeouts"
               ],
               "title": "main",
               "type": "object"

--- a/charts/baserow/values.yaml
+++ b/charts/baserow/values.yaml
@@ -139,6 +139,9 @@ frontend:
       # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
       httpsRedirect: false
 
+      # -- defines the timeouts that can be configured for an HTTP request
+      timeouts: {}
+
   autoscaling:
     # -- Enable Horizontal POD autoscaling
     enabled: false
@@ -311,6 +314,9 @@ backend:
 
         # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
         httpsRedirect: false
+
+        # -- defines the timeouts that can be configured for an HTTP request
+        timeouts: {}
 
     autoscaling:
       # -- Enable Horizontal POD autoscaling
@@ -733,6 +739,9 @@ backend:
 
         # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
         httpsRedirect: false
+
+        # -- defines the timeouts that can be configured for an HTTP request
+        timeouts: {}
 
     autoscaling:
       # -- Enable Horizontal POD autoscaling

--- a/charts/cluster-api-visualizer/CHANGELOG.md
+++ b/charts/cluster-api-visualizer/CHANGELOG.md
@@ -1,7 +1,7 @@
 # cluster-api-visualizer
 
-## 0.5.1
+## 0.6.0
 
-### Fixed
+### Added
 
-- doc for deployment strategy
+- option to define route timeouts

--- a/charts/cluster-api-visualizer/Chart.yaml
+++ b/charts/cluster-api-visualizer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-api-visualizer
 description: Multicluster resource visualization tool for Cluster API.
 type: application
-version: 0.5.1
+version: 0.6.0
 appVersion: "v1.5.0"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/cluster-api-visualizer/icon.svg
@@ -13,8 +13,8 @@ sources:
   - https://github.com/Jont828/cluster-api-visualizer
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: doc for deployment strategy
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/cluster-api-visualizer/README.md
+++ b/charts/cluster-api-visualizer/README.md
@@ -82,6 +82,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{}` | container-level security context |
 | service.port | int | `80` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/cluster-api-visualizer/templates/route.yaml
+++ b/charts/cluster-api-visualizer/templates/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/cluster-api-visualizer/values.schema.json
+++ b/charts/cluster-api-visualizer/values.schema.json
@@ -356,6 +356,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -369,7 +375,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/cluster-api-visualizer/values.yaml
+++ b/charts/cluster-api-visualizer/values.yaml
@@ -122,6 +122,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the pods.
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/countly/CHANGELOG.md
+++ b/charts/countly/CHANGELOG.md
@@ -1,7 +1,7 @@
 # countly
 
-## 4.6.17
+## 4.7.0
 
-### Changed
+### Added
 
-- dependency of mongodb to 18.6.31
+- option to define route timeouts

--- a/charts/countly/Chart.yaml
+++ b/charts/countly/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: countly
 description: Countly is a product analytics platform that helps teams track, analyze and act-on their user actions and behaviour on mobile, web and desktop applications.
 type: application
-version: 4.6.17
+version: 4.7.0
 appVersion: "25.05.4"
 home: https://github.com/christianknell/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/countly/icon.svg
@@ -19,8 +19,8 @@ dependencies:
     condition: mongodb.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: dependency of mongodb to 18.6.31
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/countly/README.md
+++ b/charts/countly/README.md
@@ -88,6 +88,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | api.route.main.labels | object | `{}` | Add labels to the route |
 | api.route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | api.route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| api.route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | api.securityContext | object | `{}` | container-level security context |
 | api.selectorLabels | object | `{}` | Additional labels to add to the pod |
 | api.service.port | int | `3000` | Kubernetes port where service is exposed |
@@ -147,6 +148,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | frontend.route.main.labels | object | `{}` | Add labels to the route |
 | frontend.route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | frontend.route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| frontend.route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | frontend.securityContext | object | `{}` | container-level security context |
 | frontend.selectorLabels | object | `{}` | Additional labels to add to the pod |
 | frontend.service.port | int | `3000` | Kubernetes port where service is exposed |

--- a/charts/countly/templates/api/route.yaml
+++ b/charts/countly/templates/api/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/countly/templates/frontend/route.yaml
+++ b/charts/countly/templates/frontend/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/countly/values.schema.json
+++ b/charts/countly/values.schema.json
@@ -465,6 +465,12 @@
                   },
                   "title": "parentRefs",
                   "type": "array"
+                },
+                "timeouts": {
+                  "description": "defines the timeouts that can be configured for an HTTP request",
+                  "required": [],
+                  "title": "timeouts",
+                  "type": "object"
                 }
               },
               "required": [
@@ -478,7 +484,8 @@
                 "matches",
                 "filters",
                 "additionalRules",
-                "httpsRedirect"
+                "httpsRedirect",
+                "timeouts"
               ],
               "title": "main",
               "type": "object"
@@ -1156,6 +1163,12 @@
                   },
                   "title": "parentRefs",
                   "type": "array"
+                },
+                "timeouts": {
+                  "description": "defines the timeouts that can be configured for an HTTP request",
+                  "required": [],
+                  "title": "timeouts",
+                  "type": "object"
                 }
               },
               "required": [
@@ -1169,7 +1182,8 @@
                 "matches",
                 "filters",
                 "additionalRules",
-                "httpsRedirect"
+                "httpsRedirect",
+                "timeouts"
               ],
               "title": "main",
               "type": "object"

--- a/charts/countly/values.yaml
+++ b/charts/countly/values.yaml
@@ -116,6 +116,9 @@ api:
       # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
       httpsRedirect: false
 
+      # -- defines the timeouts that can be configured for an HTTP request
+      timeouts: {}
+
   autoscaling:
     # -- Enable Horizontal POD autoscaling
     enabled: false
@@ -273,6 +276,9 @@ frontend:
 
       # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
       httpsRedirect: false
+
+      # -- defines the timeouts that can be configured for an HTTP request
+      timeouts: {}
 
   autoscaling:
     # -- Enable Horizontal POD autoscaling

--- a/charts/dns-exporter/CHANGELOG.md
+++ b/charts/dns-exporter/CHANGELOG.md
@@ -1,11 +1,7 @@
 # dns-exporter
 
-## 2.4.0
+## 2.5.0
 
-### Changed
+### Added
 
-- App version to v1.2.2
-
-### Fixed
-
-- docs for module configuration
+- option to define route timeouts

--- a/charts/dns-exporter/Chart.yaml
+++ b/charts/dns-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dns-exporter
 description: A multi-target Prometheus exporter with an exclusive focus on DNS monitoring
 type: application
-version: 2.4.0
+version: 2.5.0
 appVersion: "v1.2.2"
 home: https://github.com/christianhuth/helm-charts
 maintainers:
@@ -13,10 +13,8 @@ sources:
 annotations:
   artifacthub.io/category: monitoring-logging
   artifacthub.io/changes: |
-    - kind: fixed
-      description: docs for module configuration
-    - kind: changed
-      description: App version to v1.2.2
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/dns-exporter/README.md
+++ b/charts/dns-exporter/README.md
@@ -156,6 +156,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{}` | container-level security context |
 | service.port | int | `80` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/dns-exporter/templates/route.yaml
+++ b/charts/dns-exporter/templates/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/dns-exporter/values.schema.json
+++ b/charts/dns-exporter/values.schema.json
@@ -511,6 +511,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -524,7 +530,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/dns-exporter/values.yaml
+++ b/charts/dns-exporter/values.yaml
@@ -115,6 +115,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the headwind pods.
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/dnsbl-exporter/CHANGELOG.md
+++ b/charts/dnsbl-exporter/CHANGELOG.md
@@ -1,7 +1,7 @@
 # dnsbl-exporter
 
-## 1.3.1
+## 1.4.0
 
-### Fixed
+### Added
 
-- doc for deployment strategy
+- option to define route timeouts

--- a/charts/dnsbl-exporter/Chart.yaml
+++ b/charts/dnsbl-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dnsbl-exporter
 description: Prometheus compatible exporter to query DNSBLs/RBLs.
 type: application
-version: 1.3.1
+version: 1.4.0
 appVersion: "v0.7.0-rc3"
 home: https://github.com/christianhuth/helm-charts
 maintainers:
@@ -13,8 +13,8 @@ sources:
 annotations:
   artifacthub.io/category: monitoring-logging
   artifacthub.io/changes: |
-    - kind: fixed
-      description: doc for deployment strategy
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/dnsbl-exporter/README.md
+++ b/charts/dnsbl-exporter/README.md
@@ -102,6 +102,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534}` | container-level security context |
 | service.port | int | `80` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/dnsbl-exporter/templates/route.yaml
+++ b/charts/dnsbl-exporter/templates/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/dnsbl-exporter/values.schema.json
+++ b/charts/dnsbl-exporter/values.schema.json
@@ -565,6 +565,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -578,7 +584,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/dnsbl-exporter/values.yaml
+++ b/charts/dnsbl-exporter/values.yaml
@@ -116,6 +116,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the dnsbl exporter pods.
 resources:
   limits:

--- a/charts/freshrss/CHANGELOG.md
+++ b/charts/freshrss/CHANGELOG.md
@@ -1,7 +1,7 @@
 # freshrss
 
-## 2.9.2
+## 2.10.0
 
-### Changed
+### Added
 
-- dependency of postgresql to 18.6.2
+- option to define route timeouts

--- a/charts/freshrss/Chart.yaml
+++ b/charts/freshrss/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: freshrss
 description: FreshRSS is a free, self-hostable feed aggregator
 type: application
-version: 2.9.2
+version: 2.10.0
 appVersion: "1.28.1"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/freshrss/icon.svg
@@ -19,8 +19,8 @@ dependencies:
     condition: postgresql.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: dependency of postgresql to 18.6.2
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/freshrss/README.md
+++ b/charts/freshrss/README.md
@@ -128,6 +128,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{}` | container-level security context |
 | service.port | int | `8080` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/freshrss/templates/route.yaml
+++ b/charts/freshrss/templates/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/freshrss/values.schema.json
+++ b/charts/freshrss/values.schema.json
@@ -763,6 +763,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -776,7 +782,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/freshrss/values.yaml
+++ b/charts/freshrss/values.yaml
@@ -119,6 +119,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the freshrss pods.
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/github-exporter/CHANGELOG.md
+++ b/charts/github-exporter/CHANGELOG.md
@@ -1,7 +1,7 @@
 # github-exporter
 
-## 2.4.0
+## 2.5.0
 
-### Changed
+### Added
 
-- App Version to v2.3.0
+- option to define route timeouts

--- a/charts/github-exporter/Chart.yaml
+++ b/charts/github-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: github-exporter
 description: A Helm Chart for the GitHub Prometheus Exporter
 type: application
-version: 2.4.0
+version: 2.5.0
 appVersion: "v2.3.0"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/github-exporter/icon.svg
@@ -13,8 +13,8 @@ sources:
   - https://github.com/githubexporter/github-exporter
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: App Version to v2.3.0
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/github-exporter/README.md
+++ b/charts/github-exporter/README.md
@@ -91,6 +91,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{}` | container-level security context |
 | service.port | int | `9171` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/github-exporter/templates/route.yaml
+++ b/charts/github-exporter/templates/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/github-exporter/values.schema.json
+++ b/charts/github-exporter/values.schema.json
@@ -472,6 +472,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -485,7 +491,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/github-exporter/values.yaml
+++ b/charts/github-exporter/values.yaml
@@ -123,6 +123,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: true

--- a/charts/goldpinger/CHANGELOG.md
+++ b/charts/goldpinger/CHANGELOG.md
@@ -1,7 +1,7 @@
 # goldpinger
 
-## 1.2.2
+## 1.3.0
 
-### Changed
+### Added
 
-- App Version to 3.11.2
+- option to define route timeouts

--- a/charts/goldpinger/Chart.yaml
+++ b/charts/goldpinger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: goldpinger
 description: Debugging tool for Kubernetes which tests and displays connectivity between nodes in the cluster.
 type: application
-version: 1.2.2
+version: 1.3.0
 appVersion: "3.11.2"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/goldpinger/icon.svg
@@ -13,8 +13,8 @@ sources:
   - https://github.com/bloomberg/goldpinger
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: App Version to 3.11.2
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/goldpinger/README.md
+++ b/charts/goldpinger/README.md
@@ -113,6 +113,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | container-level security context |
 | service.port | int | `8080` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/goldpinger/templates/route.yaml
+++ b/charts/goldpinger/templates/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/goldpinger/values.schema.json
+++ b/charts/goldpinger/values.schema.json
@@ -806,6 +806,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -819,7 +825,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/goldpinger/values.yaml
+++ b/charts/goldpinger/values.yaml
@@ -141,6 +141,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the headwind pods.
 resources:
   limits:

--- a/charts/headwind-mdm/CHANGELOG.md
+++ b/charts/headwind-mdm/CHANGELOG.md
@@ -1,7 +1,7 @@
 # headwind-mdm
 
-## 5.4.2
+## 5.5.0
 
-### Changed
+### Added
 
-- dependency of postgresql to 18.6.2
+- option to define route timeouts

--- a/charts/headwind-mdm/Chart.yaml
+++ b/charts/headwind-mdm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: headwind-mdm
 description: Headwind MDM - an open source mobile device management software for Android
 type: application
-version: 5.4.2
+version: 5.5.0
 appVersion: "0.1.7"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/headwind-mdm/icon.svg
@@ -20,8 +20,8 @@ dependencies:
     condition: postgresql.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: dependency of postgresql to 18.6.2
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/headwind-mdm/README.md
+++ b/charts/headwind-mdm/README.md
@@ -111,6 +111,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{}` | container-level security context |
 | service.port | int | `8080` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/headwind-mdm/templates/route.yaml
+++ b/charts/headwind-mdm/templates/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/headwind-mdm/values.schema.json
+++ b/charts/headwind-mdm/values.schema.json
@@ -618,6 +618,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -631,7 +637,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/headwind-mdm/values.yaml
+++ b/charts/headwind-mdm/values.yaml
@@ -117,6 +117,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the headwind pods.
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/keycloak-mcp-server/CHANGELOG.md
+++ b/charts/keycloak-mcp-server/CHANGELOG.md
@@ -1,7 +1,7 @@
 # keycloak-mcp-server
 
-## 1.0.1
+## 1.1.0
 
-### Fixed
+### Added
 
-- problem in hpa template
+- option to define route timeouts

--- a/charts/keycloak-mcp-server/Chart.yaml
+++ b/charts/keycloak-mcp-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak-mcp-server
 description: An MCP server for Keycloak, designed to work with Keycloak for identity and access management, covering, Users, Realms, Clients, Roles, Groups, IDPs, Authentication
 type: application
-version: 1.0.1
+version: 1.1.0
 appVersion: "0.3.0"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/keycloak-mcp-server/icon.svg
@@ -14,8 +14,8 @@ sources:
 annotations:
   artifacthub.io/category: ai-machine-learning
   artifacthub.io/changes: |
-    - kind: fixed
-      description: problem in hpa template
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/keycloak-mcp-server/README.md
+++ b/charts/keycloak-mcp-server/README.md
@@ -104,6 +104,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | see [values.yaml](./values.yaml) | container-level security context |
 | service.port | int | `80` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/keycloak-mcp-server/templates/route.yaml
+++ b/charts/keycloak-mcp-server/templates/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/keycloak-mcp-server/values.schema.json
+++ b/charts/keycloak-mcp-server/values.schema.json
@@ -619,6 +619,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -632,7 +638,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/keycloak-mcp-server/values.yaml
+++ b/charts/keycloak-mcp-server/values.yaml
@@ -120,6 +120,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the pods.
 # @default -- see [values.yaml](./values.yaml)
 resources:

--- a/charts/kube-ops-view/CHANGELOG.md
+++ b/charts/kube-ops-view/CHANGELOG.md
@@ -1,7 +1,7 @@
 # kube-ops-view
 
-## 8.1.1
+## 8.2.0
 
-### Changed
+### Added
 
-- dependency of redis to 25.4.1
+- option to define route timeouts

--- a/charts/kube-ops-view/Chart.yaml
+++ b/charts/kube-ops-view/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: kube-ops-view
 description: A Helm chart for bootstrapping kube-ops-view.
 type: application
-version: 8.1.1
+version: 8.2.0
 appVersion: "23.5.0"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/kube-ops-view/icon.svg
@@ -20,8 +20,8 @@ dependencies:
 annotations:
   artifacthub.io/category: monitoring-logging
   artifacthub.io/changes: |
-    - kind: changed
-      description: dependency of redis to 25.4.1
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/kube-ops-view/README.md
+++ b/charts/kube-ops-view/README.md
@@ -84,6 +84,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":1000}` | container-level security context |
 | service.port | int | `80` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/kube-ops-view/templates/route.yaml
+++ b/charts/kube-ops-view/templates/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-ops-view/values.schema.json
+++ b/charts/kube-ops-view/values.schema.json
@@ -348,6 +348,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -361,7 +367,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/kube-ops-view/values.yaml
+++ b/charts/kube-ops-view/values.yaml
@@ -150,6 +150,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 redis:
   # -- Redis™ architecture. Allowed values: standalone or replication
   architecture: standalone

--- a/charts/kubevirt-manager/CHANGELOG.md
+++ b/charts/kubevirt-manager/CHANGELOG.md
@@ -1,7 +1,7 @@
 # kubevirt-manager
 
-## 0.5.2
+## 0.6.0
 
-### Changed
+### Added
 
-- App Version to 1.5.4
+- option to define route timeouts

--- a/charts/kubevirt-manager/Chart.yaml
+++ b/charts/kubevirt-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kubevirt-manager
 description: KubeVirt Web UI to manage the lifecycle of Virtual Machines and more
 type: application
-version: 0.5.2
+version: 0.6.0
 appVersion: "1.5.4"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/kubevirt-manager/icon.svg
@@ -13,8 +13,8 @@ sources:
   - https://github.com/kubevirt-manager/kubevirt-manager
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: App Version to 1.5.4
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/kubevirt-manager/README.md
+++ b/charts/kubevirt-manager/README.md
@@ -95,6 +95,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":30000,"runAsNonRoot":true,"runAsUser":10000,"seccompProfile":{"type":"RuntimeDefault"}}` | container-level security context |
 | service.port | int | `8080` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/kubevirt-manager/templates/kubevirt-manager/route.yaml
+++ b/charts/kubevirt-manager/templates/kubevirt-manager/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kubevirt-manager/values.schema.json
+++ b/charts/kubevirt-manager/values.schema.json
@@ -478,6 +478,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -491,7 +497,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/kubevirt-manager/values.yaml
+++ b/charts/kubevirt-manager/values.yaml
@@ -135,6 +135,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the pods.
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/kutt/CHANGELOG.md
+++ b/charts/kutt/CHANGELOG.md
@@ -1,7 +1,7 @@
 # kutt
 
-## 9.2.2
+## 9.3.0
 
-### Changed
+### Added
 
-- dependency of postgresql to 18.6.2
+- option to define route timeouts

--- a/charts/kutt/Chart.yaml
+++ b/charts/kutt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kutt
 description: Kutt is a free modern URL shortener.
 type: application
-version: 9.2.2
+version: 9.3.0
 appVersion: "v3.2.3"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/kutt/icon.svg
@@ -22,8 +22,8 @@ dependencies:
     condition: redis.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: dependency of postgresql to 18.6.2
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/kutt/README.md
+++ b/charts/kutt/README.md
@@ -133,6 +133,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{}` | container-level security context |
 | service.port | int | `80` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/kutt/templates/kutt/route.yaml
+++ b/charts/kutt/templates/kutt/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kutt/values.schema.json
+++ b/charts/kutt/values.schema.json
@@ -863,6 +863,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -876,7 +882,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/kutt/values.yaml
+++ b/charts/kutt/values.yaml
@@ -122,6 +122,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the pods.
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/mailcow-exporter/CHANGELOG.md
+++ b/charts/mailcow-exporter/CHANGELOG.md
@@ -1,7 +1,7 @@
 # mailcow-exporter
 
-## 1.3.1
+## 1.4.0
 
-### Fixed
+### Added
 
-- problem in hpa template
+- option to define route timeouts

--- a/charts/mailcow-exporter/Chart.yaml
+++ b/charts/mailcow-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mailcow-exporter
 description: Prometheus exporter for information about a mailcow instance
 type: application
-version: 1.3.1
+version: 1.4.0
 appVersion: "2.1.0"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/mailcow-exporter/icon.svg
@@ -14,8 +14,8 @@ sources:
 annotations:
   artifacthub.io/category: monitoring-logging
   artifacthub.io/changes: |
-    - kind: fixed
-      description: problem in hpa template
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/mailcow-exporter/README.md
+++ b/charts/mailcow-exporter/README.md
@@ -92,6 +92,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{}` | container-level security context |
 | service.port | int | `80` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/mailcow-exporter/templates/exporter/route.yaml
+++ b/charts/mailcow-exporter/templates/exporter/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/mailcow-exporter/values.schema.json
+++ b/charts/mailcow-exporter/values.schema.json
@@ -442,6 +442,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -455,7 +461,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/mailcow-exporter/values.yaml
+++ b/charts/mailcow-exporter/values.yaml
@@ -115,6 +115,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the headwind pods.
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/maildev/CHANGELOG.md
+++ b/charts/maildev/CHANGELOG.md
@@ -1,7 +1,7 @@
 # maildev
 
-## 1.5.1
+## 1.6.0
 
-### Fixed
+### Added
 
-- problem in hpa template
+- option to define route timeouts

--- a/charts/maildev/Chart.yaml
+++ b/charts/maildev/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maildev
 description: MailDev is a simple way to test your emails during development with an easy to use web interface.
 type: application
-version: 1.5.1
+version: 1.6.0
 appVersion: "2.2.1"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/maildev/icon.svg
@@ -15,8 +15,8 @@ sources:
   - https://hub.docker.com/r/maildev/maildev
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: problem in hpa template
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/maildev/README.md
+++ b/charts/maildev/README.md
@@ -177,6 +177,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{}` | container-level security context |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |

--- a/charts/maildev/templates/maildev/route.yaml
+++ b/charts/maildev/templates/maildev/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/maildev/values.schema.json
+++ b/charts/maildev/values.schema.json
@@ -797,6 +797,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -810,7 +816,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/maildev/values.yaml
+++ b/charts/maildev/values.yaml
@@ -148,6 +148,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 autoscaling:
   # -- Enable Horizontal POD autoscaling
   enabled: false

--- a/charts/mcp-for-argocd/CHANGELOG.md
+++ b/charts/mcp-for-argocd/CHANGELOG.md
@@ -1,7 +1,7 @@
 # mcp-for-argocd
 
-## 1.1.0
+## 1.2.0
 
-### Changed
+### Added
 
-- App Version to v0.6.0
+- option to define route timeouts

--- a/charts/mcp-for-argocd/Chart.yaml
+++ b/charts/mcp-for-argocd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-for-argocd
 description: An implementation of Model Context Protocol (MCP) server for Argo CD
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: "v0.6.0"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/mcp-for-argocd/icon.svg
@@ -14,8 +14,8 @@ sources:
 annotations:
   artifacthub.io/category: ai-machine-learning
   artifacthub.io/changes: |
-    - kind: changed
-      description: App Version to v0.6.0
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/mcp-for-argocd/README.md
+++ b/charts/mcp-for-argocd/README.md
@@ -100,6 +100,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | see [values.yaml](./values.yaml) | container-level security context |
 | service.port | int | `80` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/mcp-for-argocd/templates/route.yaml
+++ b/charts/mcp-for-argocd/templates/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/mcp-for-argocd/values.schema.json
+++ b/charts/mcp-for-argocd/values.schema.json
@@ -564,6 +564,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -577,7 +583,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/mcp-for-argocd/values.yaml
+++ b/charts/mcp-for-argocd/values.yaml
@@ -120,6 +120,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the pods.
 # @default -- see [values.yaml](./values.yaml)
 resources:

--- a/charts/netcupscp-exporter/CHANGELOG.md
+++ b/charts/netcupscp-exporter/CHANGELOG.md
@@ -1,7 +1,7 @@
 # netcupscp-exporter
 
-## 1.5.0
+## 1.6.0
 
-### Changed
+### Added
 
-- App Version to v0.5.0
+- option to define route timeouts

--- a/charts/netcupscp-exporter/Chart.yaml
+++ b/charts/netcupscp-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: netcupscp-exporter
 description: Prometheus Exporter for Netcup Server Control Panel (SCP)
 type: application
-version: 1.5.0
+version: 1.6.0
 appVersion: "v0.5.0"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/netcupscp-exporter/icon.svg
@@ -14,8 +14,8 @@ sources:
 annotations:
   artifacthub.io/category: monitoring-logging
   artifacthub.io/changes: |
-    - kind: changed
-      description: App Version to v0.5.0
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/netcupscp-exporter/README.md
+++ b/charts/netcupscp-exporter/README.md
@@ -85,6 +85,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{}` | container-level security context |
 | service.port | int | `80` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/netcupscp-exporter/templates/route.yaml
+++ b/charts/netcupscp-exporter/templates/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/netcupscp-exporter/values.schema.json
+++ b/charts/netcupscp-exporter/values.schema.json
@@ -360,6 +360,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -373,7 +379,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/netcupscp-exporter/values.yaml
+++ b/charts/netcupscp-exporter/values.yaml
@@ -115,6 +115,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the headwind pods.
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/nextcloud-exporter/CHANGELOG.md
+++ b/charts/nextcloud-exporter/CHANGELOG.md
@@ -1,7 +1,7 @@
 # nextcloud-exporter
 
-## 1.3.2
+## 1.4.0
 
-### Changed
+### Added
 
-- App Version to 0.9.1
+- option to define route timeouts

--- a/charts/nextcloud-exporter/Chart.yaml
+++ b/charts/nextcloud-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nextcloud-exporter
 description: Prometheus exporter for Nextcloud servers
 type: application
-version: 1.3.2
+version: 1.4.0
 appVersion: "0.9.1"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/nextcloud-exporter/icon.svg
@@ -14,8 +14,8 @@ sources:
 annotations:
   artifacthub.io/category: monitoring-logging
   artifacthub.io/changes: |
-    - kind: changed
-      description: App Version to 0.9.1
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/nextcloud-exporter/README.md
+++ b/charts/nextcloud-exporter/README.md
@@ -95,6 +95,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{}` | container-level security context |
 | service.port | int | `80` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/nextcloud-exporter/templates/route.yaml
+++ b/charts/nextcloud-exporter/templates/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/nextcloud-exporter/values.schema.json
+++ b/charts/nextcloud-exporter/values.schema.json
@@ -472,6 +472,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -485,7 +491,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/nextcloud-exporter/values.yaml
+++ b/charts/nextcloud-exporter/values.yaml
@@ -115,6 +115,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the headwind pods.
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/ntp-exporter/CHANGELOG.md
+++ b/charts/ntp-exporter/CHANGELOG.md
@@ -1,7 +1,7 @@
 # ntp-exporter
 
-## 1.2.1
+## 1.3.0
 
-### Fixed
+### Added
 
-- README
+- option to define route timeouts

--- a/charts/ntp-exporter/Chart.yaml
+++ b/charts/ntp-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ntp-exporter
 description: Prometheus exporter that checks the drift of Kubernetes node's clock against a given NTP server or servers
 type: application
-version: 1.2.1
+version: 1.3.0
 appVersion: "v2.9.0"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/ntp-exporter/icon.svg
@@ -14,8 +14,8 @@ sources:
 annotations:
   artifacthub.io/category: monitoring-logging
   artifacthub.io/changes: |
-    - kind: fixed
-      description: README
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/ntp-exporter/README.md
+++ b/charts/ntp-exporter/README.md
@@ -98,6 +98,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | see [values.yaml](./values.yaml) | container-level security context |
 | service.port | int | `80` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/ntp-exporter/templates/exporter/route.yaml
+++ b/charts/ntp-exporter/templates/exporter/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/ntp-exporter/values.schema.json
+++ b/charts/ntp-exporter/values.schema.json
@@ -715,6 +715,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -728,7 +734,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/ntp-exporter/values.yaml
+++ b/charts/ntp-exporter/values.yaml
@@ -112,6 +112,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the headwind pods.
 # @default -- see [values.yaml](./values.yaml)
 resources:

--- a/charts/polr/CHANGELOG.md
+++ b/charts/polr/CHANGELOG.md
@@ -1,7 +1,7 @@
 # polr
 
-## 4.2.1
+## 4.3.0
 
-### Fixed
+### Added
 
-- problem in hpa template
+- option to define route timeouts

--- a/charts/polr/Chart.yaml
+++ b/charts/polr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: polr
 description: Polr is a quick, modern, and open-source link shortener
 type: application
-version: 4.2.1
+version: 4.3.0
 appVersion: "2.3.0"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/polr/icon.svg
@@ -18,8 +18,8 @@ dependencies:
     version: 14.0.3
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: problem in hpa template
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/polr/README.md
+++ b/charts/polr/README.md
@@ -111,6 +111,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{}` | container-level security context |
 | service.port | int | `80` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/polr/templates/route.yaml
+++ b/charts/polr/templates/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/polr/values.schema.json
+++ b/charts/polr/values.schema.json
@@ -590,6 +590,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -603,7 +609,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/polr/values.yaml
+++ b/charts/polr/values.yaml
@@ -115,6 +115,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the headwind pods.
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/prometheus-pve-exporter/CHANGELOG.md
+++ b/charts/prometheus-pve-exporter/CHANGELOG.md
@@ -1,7 +1,7 @@
 # prometheus-pve-exporter
 
-## 2.6.3
+## 2.7.0
 
-### Changed
+### Added
 
-- App Version to 3.8.2
+- option to define route timeouts

--- a/charts/prometheus-pve-exporter/Chart.yaml
+++ b/charts/prometheus-pve-exporter/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: prometheus-pve-exporter
 description: A Helm chart for bootstrapping a PVE Exporter. Uses ServiceMonitor to collect metrics.
 type: application
-version: 2.6.3
+version: 2.7.0
 appVersion: "3.8.2"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/prometheus-pve-exporter/icon.svg
@@ -16,8 +16,8 @@ annotations:
   artifacthub.io/alternativeName: "pve-exporter"
   artifacthub.io/category: monitoring-logging
   artifacthub.io/changes: |
-    - kind: changed
-      description: App Version to 3.8.2
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/prometheus-pve-exporter/README.md
+++ b/charts/prometheus-pve-exporter/README.md
@@ -92,6 +92,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":65534}` | container-level security context |
 | service.port | int | `80` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/prometheus-pve-exporter/templates/route.yaml
+++ b/charts/prometheus-pve-exporter/templates/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/prometheus-pve-exporter/values.schema.json
+++ b/charts/prometheus-pve-exporter/values.schema.json
@@ -395,6 +395,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -408,7 +414,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/prometheus-pve-exporter/values.yaml
+++ b/charts/prometheus-pve-exporter/values.yaml
@@ -115,6 +115,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the controller pods.
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/promlens/CHANGELOG.md
+++ b/charts/promlens/CHANGELOG.md
@@ -1,7 +1,7 @@
 # promlens
 
-## 1.4.0
+## 1.5.0
 
 ### Added
 
-- support for setting priorityClassName
+- option to define route timeouts

--- a/charts/promlens/Chart.yaml
+++ b/charts/promlens/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: promlens
 description: PromLens is a tool that makes learning and using PromQL easier and more productive
 type: application
-version: 1.4.0
+version: 1.5.0
 appVersion: "v0.3.0"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/promlens/icon.svg
@@ -16,7 +16,7 @@ annotations:
   artifacthub.io/category: monitoring-logging
   artifacthub.io/changes: |
     - kind: added
-      description: support for setting priorityClassName
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/promlens/README.md
+++ b/charts/promlens/README.md
@@ -103,6 +103,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{}` | container-level security context |
 | service.port | int | `8080` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/promlens/templates/route.yaml
+++ b/charts/promlens/templates/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/promlens/values.schema.json
+++ b/charts/promlens/values.schema.json
@@ -545,6 +545,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -558,7 +564,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/promlens/values.yaml
+++ b/charts/promlens/values.yaml
@@ -118,6 +118,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the pods.
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/proxysql/CHANGELOG.md
+++ b/charts/proxysql/CHANGELOG.md
@@ -1,7 +1,7 @@
 # proxysql
 
-## 2.4.3
+## 2.5.0
 
-### Changed
+### Added
 
-- App Version to 3.0.8
+- option to define route timeouts

--- a/charts/proxysql/Chart.yaml
+++ b/charts/proxysql/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: proxysql
 description: A proxysql Helm chart for Kubernetes. Offers option to expose web interface through Ingress. Uses ServiceMonitor to collect metrics.
 type: application
-version: 2.4.3
+version: 2.5.0
 appVersion: "3.0.8"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/proxysql/icon.svg
@@ -13,8 +13,8 @@ sources:
   - https://github.com/sysown/proxysql
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: App Version to 3.0.8
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/proxysql/README.md
+++ b/charts/proxysql/README.md
@@ -120,6 +120,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{}` | container-level security context |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/charts/proxysql/templates/route.yaml
+++ b/charts/proxysql/templates/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/proxysql/values.yaml
+++ b/charts/proxysql/values.yaml
@@ -120,6 +120,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the headwind pods.
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/shlink-backend/CHANGELOG.md
+++ b/charts/shlink-backend/CHANGELOG.md
@@ -1,7 +1,7 @@
 # shlink-backend
 
-## 11.2.3
+## 11.3.0
 
-### Changed
+### Added
 
-- dependency of postgresql to 18.6.2
+- option to define route timeouts

--- a/charts/shlink-backend/Chart.yaml
+++ b/charts/shlink-backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: shlink-backend
 description: A PHP-based self-hosted URL shortener that can be used to serve shortened URLs under your own domain.
 type: application
-version: 11.2.3
+version: 11.3.0
 appVersion: "5.0.2"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/shlink-backend/icon.svg
@@ -35,8 +35,8 @@ dependencies:
     condition: redis.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: dependency of postgresql to 18.6.2
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/shlink-backend/README.md
+++ b/charts/shlink-backend/README.md
@@ -183,6 +183,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{}` | container-level security context |
 | service.port | int | `8080` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/shlink-backend/templates/shlink-backend/route.yaml
+++ b/charts/shlink-backend/templates/shlink-backend/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/shlink-backend/values.schema.json
+++ b/charts/shlink-backend/values.schema.json
@@ -1356,6 +1356,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -1369,7 +1375,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/shlink-backend/values.yaml
+++ b/charts/shlink-backend/values.yaml
@@ -123,6 +123,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the headwind pods.
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/shlink-web/CHANGELOG.md
+++ b/charts/shlink-web/CHANGELOG.md
@@ -1,7 +1,7 @@
 # shlink-web
 
-## 1.11.0
+## 1.12.0
 
-### Changed
+### Added
 
-- App Version to 4.7.0
+- option to define route timeouts

--- a/charts/shlink-web/Chart.yaml
+++ b/charts/shlink-web/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: shlink-web
 description: A  ReactJS-based progressive web application for Shlink.
 type: application
-version: 1.11.0
+version: 1.12.0
 appVersion: "4.7.0"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/shlink-web/icon.svg
@@ -14,8 +14,8 @@ sources:
   - https://shlink.io
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: App Version to 4.7.0
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/shlink-web/README.md
+++ b/charts/shlink-web/README.md
@@ -86,6 +86,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{}` | container-level security context |
 | service.port | int | `80` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/shlink-web/templates/route.yaml
+++ b/charts/shlink-web/templates/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/shlink-web/values.schema.json
+++ b/charts/shlink-web/values.schema.json
@@ -361,6 +361,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -374,7 +380,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/shlink-web/values.yaml
+++ b/charts/shlink-web/values.yaml
@@ -118,6 +118,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the headwind pods.
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/skooner/CHANGELOG.md
+++ b/charts/skooner/CHANGELOG.md
@@ -1,7 +1,7 @@
 # skooner
 
-## 0.3.1
+## 0.4.0
 
-### Fixed
+### Added
 
-- problem in hpa template
+- option to define route timeouts

--- a/charts/skooner/Chart.yaml
+++ b/charts/skooner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: skooner
 description: Simple Kubernetes real-time dashboard and management.
 type: application
-version: 0.3.1
+version: 0.4.0
 appVersion: "stable"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/skooner/icon.svg
@@ -14,8 +14,8 @@ sources:
 annotations:
   artifacthub.io/category: monitoring-logging
   artifacthub.io/changes: |
-    - kind: fixed
-      description: problem in hpa template
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/skooner/README.md
+++ b/charts/skooner/README.md
@@ -91,6 +91,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{"runAsNonRoot":true,"runAsUser":1000}` | container-level security context |
 | service.port | int | `80` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/skooner/templates/route.yaml
+++ b/charts/skooner/templates/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/skooner/values.schema.json
+++ b/charts/skooner/values.schema.json
@@ -444,6 +444,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -457,7 +463,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/skooner/values.yaml
+++ b/charts/skooner/values.yaml
@@ -115,6 +115,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the headwind pods.
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/sloop/CHANGELOG.md
+++ b/charts/sloop/CHANGELOG.md
@@ -1,7 +1,7 @@
 # sloop
 
-## 0.3.1
+## 0.4.0
 
-### Fixed
+### Added
 
-- problem in hpa template
+- option to define route timeouts

--- a/charts/sloop/Chart.yaml
+++ b/charts/sloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sloop
 description: Kubernetes History Visualization
 type: application
-version: 0.3.1
+version: 0.4.0
 appVersion: "sha-2ce8bbe"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/sloop/icon.svg
@@ -14,8 +14,8 @@ sources:
 annotations:
   artifacthub.io/category: monitoring-logging
   artifacthub.io/changes: |
-    - kind: fixed
-      description: problem in hpa template
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/sloop/README.md
+++ b/charts/sloop/README.md
@@ -90,6 +90,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{}` | container-level security context |
 | service.port | int | `80` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/sloop/templates/route.yaml
+++ b/charts/sloop/templates/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sloop/values.schema.json
+++ b/charts/sloop/values.schema.json
@@ -411,6 +411,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -424,7 +430,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/sloop/values.yaml
+++ b/charts/sloop/values.yaml
@@ -115,6 +115,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the pods.
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/squest/CHANGELOG.md
+++ b/charts/squest/CHANGELOG.md
@@ -1,7 +1,7 @@
 # squest
 
-## 6.2.1
+## 6.3.0
 
-### Changed
+### Added
 
-- dependency of mariadb to 25.0.10
+- option to define route timeouts

--- a/charts/squest/Chart.yaml
+++ b/charts/squest/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: squest
 description: Squest is a self-service portal that works on top of Red Hat Ansible Automation Platform/AWX.
 type: application
-version: 6.2.1
+version: 6.3.0
 appVersion: "1.30.0-alpine"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/squest/icon.svg
@@ -27,8 +27,8 @@ dependencies:
     condition: redis.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: dependency of mariadb to 25.0.10
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/squest/README.md
+++ b/charts/squest/README.md
@@ -207,6 +207,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | squest.route.main.labels | object | `{}` | Add labels to the route |
 | squest.route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | squest.route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| squest.route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | squest.securityContext | object | `{}` | container-level security context |
 | squest.service.port | int | `8080` | Kubernetes port where service is exposed |
 | squest.service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/squest/templates/squest/route.yaml
+++ b/charts/squest/templates/squest/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/squest/values.schema.json
+++ b/charts/squest/values.schema.json
@@ -1593,6 +1593,12 @@
                   },
                   "title": "parentRefs",
                   "type": "array"
+                },
+                "timeouts": {
+                  "description": "defines the timeouts that can be configured for an HTTP request",
+                  "required": [],
+                  "title": "timeouts",
+                  "type": "object"
                 }
               },
               "required": [
@@ -1606,7 +1612,8 @@
                 "matches",
                 "filters",
                 "additionalRules",
-                "httpsRedirect"
+                "httpsRedirect",
+                "timeouts"
               ],
               "title": "main",
               "type": "object"

--- a/charts/squest/values.yaml
+++ b/charts/squest/values.yaml
@@ -130,6 +130,9 @@ squest:
       # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
       httpsRedirect: false
 
+      # -- defines the timeouts that can be configured for an HTTP request
+      timeouts: {}
+
   # -- Resource limits and requests for the pods.
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/syncserver/CHANGELOG.md
+++ b/charts/syncserver/CHANGELOG.md
@@ -1,7 +1,7 @@
 # syncserver
 
-## 1.2.0
+## 1.3.0
 
 ### Added
 
-- support for Gateway API routes
+- option to define route timeouts

--- a/charts/syncserver/Chart.yaml
+++ b/charts/syncserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: syncserver
 description: Helm chart for Firefox Syncserver
 type: application
-version: 1.2.0
+version: 1.3.0
 appVersion: "latest"
 home: https://github.com/christianknell/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/syncserver/icon.svg
@@ -15,7 +15,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: support for Gateway API routes
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/syncserver/README.md
+++ b/charts/syncserver/README.md
@@ -87,6 +87,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{}` | container-level security context |
 | service.port | int | `5000` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/syncserver/templates/route.yaml
+++ b/charts/syncserver/templates/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/syncserver/values.schema.json
+++ b/charts/syncserver/values.schema.json
@@ -334,6 +334,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -347,7 +353,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/syncserver/values.yaml
+++ b/charts/syncserver/values.yaml
@@ -116,6 +116,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the controller pods.
 resources: {}
   # limits:

--- a/charts/syncstorage-rs/CHANGELOG.md
+++ b/charts/syncstorage-rs/CHANGELOG.md
@@ -1,7 +1,7 @@
 # syncstorage-rs
 
-## 5.0.9
+## 5.1.0
 
-### Changed
+### Added
 
-- dependency of mariadb mariadb to 25.0.10
+- option to define route timeouts

--- a/charts/syncstorage-rs/Chart.yaml
+++ b/charts/syncstorage-rs/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: syncstorage-rs
 description: A Helm chart for deploying Mozilla's Firefox Sync Storage server to Kubernetes
 type: application
-version: 5.0.9
+version: 5.1.0
 appVersion: "syncstorage-rs-mysql-0.18.2"
 home: https://github.com/christianknell/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/syncstorage-rs/icon.svg
@@ -27,8 +27,8 @@ dependencies:
     condition: tokenserver-db.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: dependency of mariadb mariadb to 25.0.10
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/syncstorage-rs/README.md
+++ b/charts/syncstorage-rs/README.md
@@ -95,6 +95,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{}` | container-level security context |
 | service.port | int | `80` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/syncstorage-rs/templates/syncstorage-rs/route.yaml
+++ b/charts/syncstorage-rs/templates/syncstorage-rs/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/syncstorage-rs/values.schema.json
+++ b/charts/syncstorage-rs/values.schema.json
@@ -442,6 +442,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -455,7 +461,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/syncstorage-rs/values.yaml
+++ b/charts/syncstorage-rs/values.yaml
@@ -116,6 +116,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the controller pods.
 resources: {}
   # limits:

--- a/charts/timetagger/CHANGELOG.md
+++ b/charts/timetagger/CHANGELOG.md
@@ -1,7 +1,7 @@
 # timetagger
 
-## 2.1.3
+## 2.2.0
 
-### Changed
+### Added
 
-- App Version to v26.1.3
+- option to define route timeouts

--- a/charts/timetagger/Chart.yaml
+++ b/charts/timetagger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: timetagger
 description: A Helm Chart for installing Timetagger, an open source time-tracker with an interactive user experience and powerful reporting.
 type: application
-version: 2.1.3
+version: 2.2.0
 appVersion: "v26.1.3"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/timetagger/icon.svg
@@ -13,8 +13,8 @@ sources:
   - https://github.com/almarklein/timetagger
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: App Version to v26.1.3
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/timetagger/README.md
+++ b/charts/timetagger/README.md
@@ -104,6 +104,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":1000}` | container-level security context |
 | service.port | int | `8080` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/timetagger/templates/route.yaml
+++ b/charts/timetagger/templates/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/timetagger/values.schema.json
+++ b/charts/timetagger/values.schema.json
@@ -617,6 +617,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -630,7 +636,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/timetagger/values.yaml
+++ b/charts/timetagger/values.yaml
@@ -116,6 +116,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 autoscaling:
   # -- Enable Horizontal POD autoscaling
   enabled: false

--- a/charts/typo3/CHANGELOG.md
+++ b/charts/typo3/CHANGELOG.md
@@ -1,7 +1,7 @@
 # typo3
 
-## 7.1.4
+## 7.2.0
 
-### Changed
+### Added
 
-- dependency of postgresql to 18.6.2
+- option to define route timeouts

--- a/charts/typo3/Chart.yaml
+++ b/charts/typo3/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: typo3
 description: TYPO3 — the Professional, Flexible Content Management System
 type: application
-version: 7.1.4
+version: 7.2.0
 appVersion: "13.4"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/typo3/icon.svg
@@ -27,8 +27,8 @@ dependencies:
     condition: postgresql.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: dependency of postgresql to 18.6.2
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/typo3/README.md
+++ b/charts/typo3/README.md
@@ -124,6 +124,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{}` | container-level security context |
 | service.port | int | `8080` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/typo3/templates/route.yaml
+++ b/charts/typo3/templates/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/typo3/values.schema.json
+++ b/charts/typo3/values.schema.json
@@ -762,6 +762,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -775,7 +781,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/typo3/values.yaml
+++ b/charts/typo3/values.yaml
@@ -115,6 +115,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 # -- Resource limits and requests for the headwind pods.
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/umami/CHANGELOG.md
+++ b/charts/umami/CHANGELOG.md
@@ -1,7 +1,7 @@
 # umami
 
-## 7.8.2
+## 7.9.0
 
-### Changed
+### Added
 
-- dependency of postgresql to 18.6.2
+- option to define route timeouts

--- a/charts/umami/Chart.yaml
+++ b/charts/umami/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: umami
 description: Umami is a simple, fast, privacy-focused alternative to Google Analytics.
 type: application
-version: 7.8.2
+version: 7.9.0
 appVersion: "v2.20.1"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/umami/icon.svg
@@ -25,8 +25,8 @@ dependencies:
 annotations:
   artifacthub.io/category: monitoring-logging
   artifacthub.io/changes: |
-    - kind: changed
-      description: dependency of postgresql to 18.6.2
+    - kind: added
+      description: option to define route timeouts
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/umami/README.md
+++ b/charts/umami/README.md
@@ -114,6 +114,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | route.main.labels | object | `{}` | Add labels to the route |
 | route.main.matches | list | see [values.yaml](./values.yaml) | define conditions used for matching the rule against incoming HTTP requests. |
 | route.main.parentRefs | list | `[]` | Parent references (Gateway) |
+| route.main.timeouts | object | `{}` | defines the timeouts that can be configured for an HTTP request |
 | securityContext | object | `{"runAsGroup":65533,"runAsNonRoot":true,"runAsUser":1001}` | container-level security context |
 | service.port | int | `3000` | Kubernetes port where service is exposed |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/umami/templates/route.yaml
+++ b/charts/umami/templates/route.yaml
@@ -48,6 +48,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/umami/values.schema.json
+++ b/charts/umami/values.schema.json
@@ -658,6 +658,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -671,7 +677,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/umami/values.yaml
+++ b/charts/umami/values.yaml
@@ -136,6 +136,9 @@ route:
     # -- adds a filter for redirecting to https (HTTP 301 Moved Permanently). To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners. Matches and filters do not take effect if enabled. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
     httpsRedirect: false
 
+    # -- defines the timeouts that can be configured for an HTTP request
+    timeouts: {}
+
 autoscaling:
   # -- Enable Horizontal POD autoscaling
   enabled: false


### PR DESCRIPTION
fixes #2856 

Charts:

- [x] audiobookshelf
- [x] baserow
- [x] cluster-api-visualizer
- [x] countly
- [x] dns-exporter
- [x] dnsbl-exporter
- [x] freshrss
- [x] github-exporter
- [x] goldpinger
- [x] headwind-mdm
- [x] keycloak-mcp-server
- [x] kube-ops-view
- [x] kubevirt-manager
- [x] kutt
- [x] mailcow-exporter
- [x] maildev
- [x] mcp-for-argocd
- [x] netcupscp-exporter
- [x] nextcloud-exporter
- [x] ntp-exporter
- [x] polr
- [x] prometheus-pve-exporter
- [x] promlens
- [x] proxysql
- [x] shlink-backend
- [x] shlink-web
- [x] skooner
- [x] sloop
- [x] squest
- [x] syncserver
- [x] syncstorage-rs
- [x] timetagger
- [x] typo3
- [x] umami