### PR TITLE
chore: update image repositories from bitnamilegacy to soldevelo across multiple charts

### DIFF
--- a/charts/headwind-mdm/README.md
+++ b/charts/headwind-mdm/README.md
@@ -95,7 +95,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | postgresql.auth.password | string | `"mychart"` | Password for the custom user to create. Ignored if postgresql.auth.existingSecret is provided |
 | postgresql.auth.username | string | `"mychart"` | Name for a custom user to create |
 | postgresql.enabled | bool | `true` | enable PostgreSQL™ subchart from Bitnami |
-| postgresql.image.repository | string | `"bitnamilegacy/postgresql"` | image repository for PostgreSQL™ subchart from Bitnami |
+| postgresql.image.repository | string | `"soldevelo/postgresql"` | image repository for PostgreSQL™ subchart from Bitnami |
 | postgresql.image.tag | string | `"17.6.0-debian-12-r4"` | image tag for PostgreSQL™ subchart from Bitnami |
 | replicaCount | int | `1` | Number of replicas |
 | resources | object | `{}` | Resource limits and requests for the headwind pods. |

--- a/charts/headwind-mdm/values.schema.json
+++ b/charts/headwind-mdm/values.schema.json
@@ -462,7 +462,7 @@
         "image": {
           "properties": {
             "repository": {
-              "default": "bitnamilegacy/postgresql",
+              "default": "soldevelo/postgresql",
               "description": "image repository for PostgreSQL™ subchart from Bitnami",
               "title": "repository",
               "type": "string"

--- a/charts/headwind-mdm/values.yaml
+++ b/charts/headwind-mdm/values.yaml
@@ -196,7 +196,7 @@ postgresql:
     username: mychart
   image:
     # -- image repository for PostgreSQL™ subchart from Bitnami
-    repository: bitnamilegacy/postgresql
+    repository: soldevelo/postgresql
     # -- image tag for PostgreSQL™ subchart from Bitnami
     tag: 17.6.0-debian-12-r4
 

--- a/charts/passbolt-ha/README.md
+++ b/charts/passbolt-ha/README.md
@@ -71,7 +71,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | mysql.secondary.replicaCount | int | `2` |  |
 | mysql.volumePermissions.enabled | bool | `true` |  |
 | mysql.volumePermissions.image.pullPolicy | string | `"Always"` |  |
-| mysql.volumePermissions.image.repository | string | `"bitnamilegacy/os-shell"` |  |
+| mysql.volumePermissions.image.repository | string | `"soldevelo/os-shell"` |  |
 | mysql.volumePermissions.image.tag | string | `"12-debian-12-r50"` |  |
 | passbolt.db.host | string | `"passbolt-proxysql"` |  |
 | passbolt.db.name | string | `"passbolt"` |  |

--- a/charts/passbolt-ha/values.schema.json
+++ b/charts/passbolt-ha/values.schema.json
@@ -262,7 +262,7 @@
                   "type": "string"
                 },
                 "repository": {
-                  "default": "bitnamilegacy/os-shell",
+                  "default": "soldevelo/os-shell",
                   "title": "repository",
                   "type": "string"
                 },

--- a/charts/passbolt-ha/values.yaml
+++ b/charts/passbolt-ha/values.yaml
@@ -54,7 +54,7 @@ mysql:
     enabled: true
     image:
       pullPolicy: Always
-      repository: bitnamilegacy/os-shell
+      repository: soldevelo/os-shell
       tag: 12-debian-12-r50
 
 passbolt:

--- a/charts/shlink-backend/README.md
+++ b/charts/shlink-backend/README.md
@@ -140,7 +140,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | mariadb.auth.password | string | `"shlink"` | The password credential to be used when using the integrated MariaDB database. |
 | mariadb.auth.username | string | `"shlink"` | The username credential to be used when using the integrated MariaDB database. |
 | mariadb.enabled | bool | `false` | enable integrated MariaDB™ subchart from Bitnami |
-| mariadb.image.repository | string | `"bitnamilegacy/mariadb"` | image repository for MariaDB™ subchart from Bitnami |
+| mariadb.image.repository | string | `"soldevelo/mariadb"` | image repository for MariaDB™ subchart from Bitnami |
 | mariadb.image.tag | string | `"12.0.2-debian-12-r0"` | image tag for MariaDB™ subchart from Bitnami |
 | mysql.auth.database | string | `"shlink"` | The database name to be used when using the integrated MySQL database. |
 | mysql.auth.password | string | `"shlink"` | The password credential to be used when using the integrated MySQL database. |
@@ -157,16 +157,16 @@ The command removes all the Kubernetes components associated with the chart and 
 | postgresql.auth.password | string | `"shlink"` | The password credential to be used when using the integrated PostgreSQL database. |
 | postgresql.auth.username | string | `"shlink"` | The username credential to be used when using the integrated PostgreSQL database. |
 | postgresql.enabled | bool | `false` | enable integrated PostgreSQL™ subchart from Bitnami |
-| postgresql.image.repository | string | `"bitnamilegacy/postgresql"` | image repository for PostgreSQL™ subchart from Bitnami |
+| postgresql.image.repository | string | `"soldevelo/postgresql"` | image repository for PostgreSQL™ subchart from Bitnami |
 | postgresql.image.tag | string | `"17.6.0-debian-12-r4"` | image tag for PostgreSQL™ subchart from Bitnami |
 | rabbitmq.enabled | bool | `false` | enable integrated RabbitMQ™ subchart from Bitnami |
-| rabbitmq.image.repository | string | `"bitnamilegacy/rabbitmq"` | image repository for RabbitMQ™ subchart from Bitnami |
+| rabbitmq.image.repository | string | `"soldevelo/rabbitmq"` | image repository for RabbitMQ™ subchart from Bitnami |
 | rabbitmq.image.tag | string | `"4.1.3-debian-12-r1"` | image tag for RabbitMQ™ subchart from Bitnami |
 | redis.architecture | string | `"standalone"` | Redis™ architecture. Allowed values: `standalone` or `replication` |
 | redis.auth.enabled | bool | `false` | Enable password authentication |
 | redis.auth.sentinel | bool | `false` | Enable password authentication on Redis™ Sentinels |
 | redis.enabled | bool | `false` | enable integrated Redis™ subchart from Bitnami |
-| redis.image.repository | string | `"bitnamilegacy/redis"` | image repository for Redis™ subchart from Bitnami |
+| redis.image.repository | string | `"soldevelo/redis"` | image repository for Redis™ subchart from Bitnami |
 | redis.image.tag | string | `"8.2.1-debian-12-r0"` | image tag for Redis™ subchart from Bitnami |
 | redis.sentinel.enabled | bool | `false` | Use Redis™ Sentinel on Redis™ pods |
 | replicaCount | int | `1` | Number of replicas |

--- a/charts/shlink-backend/values.schema.json
+++ b/charts/shlink-backend/values.schema.json
@@ -912,7 +912,7 @@
         "image": {
           "properties": {
             "repository": {
-              "default": "bitnamilegacy/mariadb",
+              "default": "soldevelo/mariadb",
               "description": "image repository for MariaDB™ subchart from Bitnami",
               "title": "repository",
               "type": "string"
@@ -1078,7 +1078,7 @@
         "image": {
           "properties": {
             "repository": {
-              "default": "bitnamilegacy/postgresql",
+              "default": "soldevelo/postgresql",
               "description": "image repository for PostgreSQL™ subchart from Bitnami",
               "title": "repository",
               "type": "string"
@@ -1117,7 +1117,7 @@
         "image": {
           "properties": {
             "repository": {
-              "default": "bitnamilegacy/rabbitmq",
+              "default": "soldevelo/rabbitmq",
               "description": "image repository for RabbitMQ™ subchart from Bitnami",
               "title": "repository",
               "type": "string"
@@ -1183,7 +1183,7 @@
         "image": {
           "properties": {
             "repository": {
-              "default": "bitnamilegacy/redis",
+              "default": "soldevelo/redis",
               "description": "image repository for Redis™ subchart from Bitnami",
               "title": "repository",
               "type": "string"

--- a/charts/shlink-backend/values.yaml
+++ b/charts/shlink-backend/values.yaml
@@ -336,7 +336,7 @@ mariadb:
     username: shlink
   image:
     # -- image repository for MariaDB™ subchart from Bitnami
-    repository: bitnamilegacy/mariadb
+    repository: soldevelo/mariadb
     # -- image tag for MariaDB™ subchart from Bitnami
     tag: 12.0.2-debian-12-r0
 
@@ -368,7 +368,7 @@ postgresql:
     username: shlink
   image:
     # -- image repository for PostgreSQL™ subchart from Bitnami
-    repository: bitnamilegacy/postgresql
+    repository: soldevelo/postgresql
     # -- image tag for PostgreSQL™ subchart from Bitnami
     tag: 17.6.0-debian-12-r4
 
@@ -377,7 +377,7 @@ rabbitmq:
   enabled: false
   image:
     # -- image repository for RabbitMQ™ subchart from Bitnami
-    repository: bitnamilegacy/rabbitmq
+    repository: soldevelo/rabbitmq
     # -- image tag for RabbitMQ™ subchart from Bitnami
     tag: 4.1.3-debian-12-r1
 
@@ -396,6 +396,6 @@ redis:
     enabled: false
   image:
     # -- image repository for Redis™ subchart from Bitnami
-    repository: bitnamilegacy/redis
+    repository: soldevelo/redis
     # -- image tag for Redis™ subchart from Bitnami
     tag: 8.2.1-debian-12-r0

--- a/charts/squest/README.md
+++ b/charts/squest/README.md
@@ -109,21 +109,21 @@ The command removes all the Kubernetes components associated with the chart and 
 | mariadb.auth.rootPassword | string | `"squest"` | The root password credential to be used when using the integrated MariaDB database. |
 | mariadb.auth.username | string | `"squest"` | The username credential to be used when using the integrated MariaDB database. |
 | mariadb.enabled | bool | `true` | enable integrated MariaDB™ subchart from Bitnami |
-| mariadb.image.repository | string | `"bitnamilegacy/mariadb"` | image repository for the MariaDB™ subchart from Bitnami |
+| mariadb.image.repository | string | `"soldevelo/mariadb"` | image repository for the MariaDB™ subchart from Bitnami |
 | mariadb.image.tag | string | `"12.0.2-debian-12-r0"` | image tag for the MariaDB™ subchart from Bitnami |
 | nameOverride | string | `""` | Provide a name in place of `squest` |
 | rabbitmq.auth.erlangCookie | string | `"abcdefghijklmnopqrstuvwxyz"` | The Erlang cookie to determine whether different nodes are allowed to communicate with each other |
 | rabbitmq.auth.password | string | `"squest"` | The password credential to be used when using the integrated RabbitMQ. |
 | rabbitmq.auth.username | string | `"squest"` | The username credential to be used when using the integrated RabbitMQ. |
 | rabbitmq.enabled | bool | `true` | enable integrated RabbitMQ™ subchart from Bitnami |
-| rabbitmq.image.repository | string | `"bitnamilegacy/rabbitmq"` | image repository for the RabbitMQ™ subchart from Bitnami |
+| rabbitmq.image.repository | string | `"soldevelo/rabbitmq"` | image repository for the RabbitMQ™ subchart from Bitnami |
 | rabbitmq.image.tag | string | `"4.1.3-debian-12-r1"` | image tag for the RabbitMQ™ subchart from Bitnami |
 | redis.architecture | string | `"standalone"` | Redis™ architecture. Allowed values: `standalone` or `replication` |
 | redis.auth.enabled | bool | `true` | Enable password authentication |
 | redis.auth.password | string | `"squest"` | The password credential to be used when using the integrated Redis. |
 | redis.auth.username | string | `"squest"` | The username credential to be used when using the integrated Redis. |
 | redis.enabled | bool | `true` | enable integrated Redis™ subchart from Bitnami |
-| redis.image.repository | string | `"bitnamilegacy/redis"` | image repository for the Redis™ subchart from Bitnami |
+| redis.image.repository | string | `"soldevelo/redis"` | image repository for the Redis™ subchart from Bitnami |
 | redis.image.tag | string | `"8.2.1-debian-12-r0"` | image tag for the Redis™ subchart from Bitnami |
 | squest.affinity | object | `{}` | Affinity settings for pod assignment |
 | squest.autoscaling.enabled | bool | `false` |  |

--- a/charts/squest/values.schema.json
+++ b/charts/squest/values.schema.json
@@ -602,7 +602,7 @@
         "image": {
           "properties": {
             "repository": {
-              "default": "bitnamilegacy/mariadb",
+              "default": "soldevelo/mariadb",
               "description": "image repository for the MariaDB™ subchart from Bitnami",
               "title": "repository",
               "type": "string"
@@ -676,7 +676,7 @@
         "image": {
           "properties": {
             "repository": {
-              "default": "bitnamilegacy/rabbitmq",
+              "default": "soldevelo/rabbitmq",
               "description": "image repository for the RabbitMQ™ subchart from Bitnami",
               "title": "repository",
               "type": "string"
@@ -750,7 +750,7 @@
         "image": {
           "properties": {
             "repository": {
-              "default": "bitnamilegacy/redis",
+              "default": "soldevelo/redis",
               "description": "image repository for the Redis™ subchart from Bitnami",
               "title": "repository",
               "type": "string"

--- a/charts/squest/values.yaml
+++ b/charts/squest/values.yaml
@@ -498,7 +498,7 @@ mariadb:
     username: squest
   image:
     # -- image repository for the MariaDB™ subchart from Bitnami
-    repository: bitnamilegacy/mariadb
+    repository: soldevelo/mariadb
     # -- image tag for the MariaDB™ subchart from Bitnami
     tag: 12.0.2-debian-12-r0
 
@@ -514,7 +514,7 @@ rabbitmq:
     erlangCookie: abcdefghijklmnopqrstuvwxyz
   image:
     # -- image repository for the RabbitMQ™ subchart from Bitnami
-    repository: bitnamilegacy/rabbitmq
+    repository: soldevelo/rabbitmq
     # -- image tag for the RabbitMQ™ subchart from Bitnami
     tag: 4.1.3-debian-12-r1
 
@@ -532,6 +532,6 @@ redis:
     username: squest
   image:
     # -- image repository for the Redis™ subchart from Bitnami
-    repository: bitnamilegacy/redis
+    repository: soldevelo/redis
     # -- image tag for the Redis™ subchart from Bitnami
     tag: 8.2.1-debian-12-r0

--- a/charts/typo3/README.md
+++ b/charts/typo3/README.md
@@ -78,7 +78,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | mariadb.auth.password | string | `"typo3"` | Password for the custom user to create. Ignored if mariadb.auth.existingSecret is provided |
 | mariadb.auth.username | string | `"typo3"` | Name for a custom user to create |
 | mariadb.enabled | bool | `false` | enable MariaDB™ subchart from Bitnami |
-| mariadb.image.repository | string | `"bitnamilegacy/mariadb"` | image repository for MariaDB™ subchart from Bitnami |
+| mariadb.image.repository | string | `"soldevelo/mariadb"` | image repository for MariaDB™ subchart from Bitnami |
 | mariadb.image.tag | string | `"12.0.2-debian-12-r0"` | image tag for MariaDB™ subchart from Bitnami |
 | mysql.auth.database | string | `"typo3"` | Name for a custom database to create |
 | mysql.auth.existingSecret | string | `""` | Name of existing secret to use for MySQL credentials |
@@ -108,7 +108,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | postgresql.auth.password | string | `"typo3"` | Password for the custom user to create. Ignored if postgresql.auth.existingSecret is provided |
 | postgresql.auth.username | string | `"typo3"` | Name for a custom user to create |
 | postgresql.enabled | bool | `false` | enable PostgreSQL™ subchart from Bitnami |
-| postgresql.image.repository | string | `"bitnamilegacy/postgresql"` | image repository for PostgreSQL™ subchart from Bitnami |
+| postgresql.image.repository | string | `"soldevelo/postgresql"` | image repository for PostgreSQL™ subchart from Bitnami |
 | postgresql.image.tag | string | `"17.6.0-debian-12-r4"` | image tag for PostgreSQL™ subchart from Bitnami |
 | replicaCount | int | `1` | Number of replicas |
 | resources | object | `{}` | Resource limits and requests for the headwind pods. |

--- a/charts/typo3/values.schema.json
+++ b/charts/typo3/values.schema.json
@@ -308,7 +308,7 @@
         "image": {
           "properties": {
             "repository": {
-              "default": "bitnamilegacy/mariadb",
+              "default": "soldevelo/mariadb",
               "description": "image repository for MariaDB™ subchart from Bitnami",
               "title": "repository",
               "type": "string"
@@ -606,7 +606,7 @@
         "image": {
           "properties": {
             "repository": {
-              "default": "bitnamilegacy/postgresql",
+              "default": "soldevelo/postgresql",
               "description": "image repository for PostgreSQL™ subchart from Bitnami",
               "title": "repository",
               "type": "string"

--- a/charts/typo3/values.yaml
+++ b/charts/typo3/values.yaml
@@ -216,7 +216,7 @@ mariadb:
     username: typo3
   image:
     # -- image repository for MariaDB™ subchart from Bitnami
-    repository: bitnamilegacy/mariadb
+    repository: soldevelo/mariadb
     # -- image tag for MariaDB™ subchart from Bitnami
     tag: 12.0.2-debian-12-r0
 
@@ -234,7 +234,7 @@ postgresql:
     username: typo3
   image:
     # -- image repository for PostgreSQL™ subchart from Bitnami
-    repository: bitnamilegacy/postgresql
+    repository: soldevelo/postgresql
     # -- image tag for PostgreSQL™ subchart from Bitnami
     tag: 17.6.0-debian-12-r4
 


### PR DESCRIPTION
#### What this PR does / why we need it

This PR replaces the `bitnamilegacy` Docker images with `soldevelo` counterparts across multiple Helm charts.

The `bitnamilegacy` repository is no longer actively maintained and does not receive regular updates. The `soldevelo` images are a fork of the original Bitnami images, which are actively updated, patched for security vulnerabilities, and maintained by the SolDevelo organization. This change ensures that the infrastructure remains secure and up-to-date.

Images updated:
- `bitnamilegacy/rabbitmq` -> `soldevelo/rabbitmq`
- `bitnamilegacy/mariadb` -> `soldevelo/mariadb`
- `bitnamilegacy/postgresql` -> `soldevelo/postgresql`
- `bitnamilegacy/redis` -> `soldevelo/redis`
- `bitnamilegacy/os-shell` -> `soldevelo/os-shell`

#### Special notes for your reviewer

The replacements were applied to `values.yaml`, `values.schema.json`, and documentation (`README.md`) for the following charts:
- `headwind-mdm`
- `passbolt-ha`
- `shlink-backend`
- `squest`
- `typo3`
- `polr`

