### PR TITLE
[proxysql] add reloadOnRestart to toggle the --reload startup flag

### DIFF
--- a/charts/proxysql/CHANGELOG.md
+++ b/charts/proxysql/CHANGELOG.md
@@ -1,7 +1,7 @@
 # proxysql
 
-## 3.0.2
+## 3.1.0
 
-### Changed
+### Added
 
-- App Version to 3.0.10
+- proxysql.config.reloadOnRestart value to control the --reload startup flag

--- a/charts/proxysql/Chart.yaml
+++ b/charts/proxysql/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: proxysql
 description: A proxysql Helm chart for Kubernetes. Offers option to expose web interface through Ingress. Uses ServiceMonitor to collect metrics.
 type: application
-version: 3.0.2
+version: 3.1.0
 appVersion: "3.0.10"
 home: https://github.com/christianhuth/helm-charts
 icon: https://raw.githubusercontent.com/christianhuth/helm-charts/refs/heads/main/charts/proxysql/icon.svg
@@ -13,8 +13,8 @@ sources:
   - https://github.com/sysown/proxysql
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: App Version to 3.0.10
+    - kind: added
+      description: proxysql.config.reloadOnRestart value to control the --reload startup flag
   artifacthub.io/links: |
     - name: support
       url: https://github.com/christianhuth/helm-charts/issues

--- a/charts/proxysql/README.md
+++ b/charts/proxysql/README.md
@@ -42,6 +42,17 @@ helm uninstall my-release
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
+## Configuration ownership: Helm values vs. runtime admin changes
+
+ProxySQL can be configured two ways: through the config file this chart renders from Helm values (`/etc/proxysql.cnf`), and at runtime through the admin interface (`LOAD ... TO RUNTIME; SAVE ... TO DISK`), which persists to the config database (`/var/lib/proxysql/proxysql.db`).
+
+The `proxysql.config.reloadOnRestart` value controls which side wins after a restart:
+
+- `true` (default): ProxySQL starts with the `--reload` flag. On **every** container start the rendered config file is merged over the persisted config database — every key present in the config file is reset to its Helm-values state, silently reverting runtime admin changes to those keys, even with persistence enabled. Use this when Helm values are your single source of truth (e.g. GitOps). Note that ProxySQL's startup message "Ignoring configuration file ... as the config DB has higher precedence" is printed even when `--reload` has just merged the file, so do not rely on it.
+- `false`: the config file is only read when no config database exists yet (first boot). Runtime admin changes are durable across restarts — this matches ProxySQL's documented operating model. The trade-off: with persistence enabled, later changes to Helm values are **not** applied to an existing config database; reconfigure through the admin interface, or delete `/var/lib/proxysql/proxysql.db` (or the PVC) to re-bootstrap from the config file.
+
+If you manage ProxySQL configuration at runtime through the admin interface, set `reloadOnRestart: false` — otherwise a full restart of all replicas (node pool upgrade, StatefulSet recreation, scale-from-zero) reverts your runtime configuration. With multiple clustered replicas this revert is masked by peer-sync during rolling restarts and only surfaces when all pods boot fresh simultaneously.
+
 ## Values
 
 | Key | Type | Default | Description |
@@ -81,6 +92,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | proxysql.cluster.password | string | `"cluster"` |  |
 | proxysql.cluster.user | string | `"cluster"` |  |
 | proxysql.config.existingSecret | string | `""` | Use an existing Secret containing the proxysql.cnf config. The secret has to contain the key `proxysql.cnf`. When it's set the chart will not generate a Secret. |
+| proxysql.config.reloadOnRestart | bool | `true` | Start ProxySQL with the `--reload` flag. When true, the rendered proxysql.cnf is merged into the persisted config DB on every container start, overwriting runtime admin changes (LOAD ... TO RUNTIME; SAVE ... TO DISK) for every key present in the config file. When false, the config file is only read when no config DB exists yet (first boot), making runtime admin changes durable across restarts, but Helm values changes to the config then no longer apply over an existing config DB. |
 | proxysql.monitor.enabled | bool | `false` |  |
 | proxysql.monitor.replicationLagInterval | int | `10000` |  |
 | proxysql.monitor.replicationLagTimeout | int | `1500` |  |

--- a/charts/proxysql/README.md.gotmpl
+++ b/charts/proxysql/README.md.gotmpl
@@ -41,6 +41,17 @@ helm uninstall my-release
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
+## Configuration ownership: Helm values vs. runtime admin changes
+
+ProxySQL can be configured two ways: through the config file this chart renders from Helm values (`/etc/proxysql.cnf`), and at runtime through the admin interface (`LOAD ... TO RUNTIME; SAVE ... TO DISK`), which persists to the config database (`/var/lib/proxysql/proxysql.db`).
+
+The `proxysql.config.reloadOnRestart` value controls which side wins after a restart:
+
+- `true` (default): ProxySQL starts with the `--reload` flag. On **every** container start the rendered config file is merged over the persisted config database — every key present in the config file is reset to its Helm-values state, silently reverting runtime admin changes to those keys, even with persistence enabled. Use this when Helm values are your single source of truth (e.g. GitOps). Note that ProxySQL's startup message "Ignoring configuration file ... as the config DB has higher precedence" is printed even when `--reload` has just merged the file, so do not rely on it.
+- `false`: the config file is only read when no config database exists yet (first boot). Runtime admin changes are durable across restarts — this matches ProxySQL's documented operating model. The trade-off: with persistence enabled, later changes to Helm values are **not** applied to an existing config database; reconfigure through the admin interface, or delete `/var/lib/proxysql/proxysql.db` (or the PVC) to re-bootstrap from the config file.
+
+If you manage ProxySQL configuration at runtime through the admin interface, set `reloadOnRestart: false` — otherwise a full restart of all replicas (node pool upgrade, StatefulSet recreation, scale-from-zero) reverts your runtime configuration. With multiple clustered replicas this revert is masked by peer-sync during rolling restarts and only surfaces when all pods boot fresh simultaneously.
+
 {{ template "chart.valuesSection" . }}
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/charts/proxysql/templates/_pod.tpl
+++ b/charts/proxysql/templates/_pod.tpl
@@ -26,7 +26,9 @@ spec:
         - "--idle-threads"
         - "-D"
         - "/var/lib/proxysql"
+        {{- if .Values.proxysql.config.reloadOnRestart }}
         - "--reload"
+        {{- end }}
       ports:
         - name: mysql
           containerPort: {{ .Values.proxysql.mysql.port }}

--- a/charts/proxysql/values.schema.json
+++ b/charts/proxysql/values.schema.json
@@ -356,12 +356,34 @@
             }
           },
           "required": [
+            "enabled",
             "user",
             "password",
-            "enabled",
             "claim"
           ],
           "title": "cluster",
+          "type": "object"
+        },
+        "config": {
+          "properties": {
+            "existingSecret": {
+              "default": "",
+              "description": "Use an existing Secret containing the proxysql.cnf config. The secret has to contain the key `proxysql.cnf`. When it's set the chart will not generate a Secret.",
+              "title": "existingSecret",
+              "type": "string"
+            },
+            "reloadOnRestart": {
+              "default": true,
+              "description": "Start ProxySQL with the `--reload` flag. When true, the rendered proxysql.cnf is merged into the persisted config DB on every container start, overwriting runtime admin changes (LOAD ... TO RUNTIME; SAVE ... TO DISK) for every key present in the config file. When false, the config file is only read when no config DB exists yet (first boot), making runtime admin changes durable across restarts, but Helm values changes to the config then no longer apply over an existing config DB.",
+              "title": "reloadOnRestart",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "existingSecret",
+            "reloadOnRestart"
+          ],
+          "title": "config",
           "type": "object"
         },
         "monitor": {
@@ -535,12 +557,6 @@
           "title": "port",
           "type": "integer"
         },
-        "existingSecret": {
-          "default": "",
-          "description": "Use an existing Secret containing the proxysql.cnf config. The secret has to contain the key `proxysql.cnf`. When it's set the chart will not generate a Secret.",
-          "title": "existingSecret",
-          "type": "string"
-        },
         "web": {
           "properties": {
             "enabled": {
@@ -574,7 +590,15 @@
           "type": "object"
         }
       },
-      "required": [],
+      "required": [
+        "config",
+        "web",
+        "admin",
+        "port",
+        "cluster",
+        "mysql",
+        "monitor"
+      ],
       "title": "proxysql",
       "type": "object"
     },
@@ -706,6 +730,12 @@
               },
               "title": "parentRefs",
               "type": "array"
+            },
+            "timeouts": {
+              "description": "defines the timeouts that can be configured for an HTTP request",
+              "required": [],
+              "title": "timeouts",
+              "type": "object"
             }
           },
           "required": [
@@ -719,7 +749,8 @@
             "matches",
             "filters",
             "additionalRules",
-            "httpsRedirect"
+            "httpsRedirect",
+            "timeouts"
           ],
           "title": "main",
           "type": "object"

--- a/charts/proxysql/values.yaml
+++ b/charts/proxysql/values.yaml
@@ -156,6 +156,8 @@ proxysql:
   config:
     # -- Use an existing Secret containing the proxysql.cnf config. The secret has to contain the key `proxysql.cnf`. When it's set the chart will not generate a Secret.
     existingSecret: ""
+    # -- Start ProxySQL with the `--reload` flag. When true, the rendered proxysql.cnf is merged into the persisted config DB on every container start, overwriting runtime admin changes (LOAD ... TO RUNTIME; SAVE ... TO DISK) for every key present in the config file. When false, the config file is only read when no config DB exists yet (first boot), making runtime admin changes durable across restarts, but Helm values changes to the config then no longer apply over an existing config DB.
+    reloadOnRestart: true
   web:
     enabled: true
     port: 443


### PR DESCRIPTION
#### What this PR does / why we need it

The chart hardcodes `--reload` in the ProxySQL start command (`templates/_pod.tpl`). On **every** container start `--reload` merges the values-rendered `/etc/proxysql.cnf` over the persisted config DB, silently reverting runtime admin changes (`LOAD ... TO RUNTIME; SAVE ... TO DISK`) — even with persistence enabled.

This PR adds `proxysql.config.reloadOnRestart` (default `true`, so current behavior is unchanged) to control whether `--reload` is passed:

- `true` (default): Helm values win on every restart (GitOps-style single source of truth).
- `false`: the config file is only read on first boot; runtime admin changes become durable across restarts.

The trade-off is documented in the README under a new "Configuration ownership" section. The change is a single conditional in the shared pod template, so it covers both the Deployment and StatefulSet paths.

#### Which issue this PR fixes

- fixes #

#### Special notes for your reviewer

Backward-compatible; no default behavior change (minor version bump `3.0.2` → `3.1.0`). Generated files (`README.md`, `values.schema.json`, `CHANGELOG.md`) regenerated via the repo's helm-docs / helm-schema / changelog tooling.

/cc @christianhuth

#### Checklist

- [x] Target a branch starting with `dev-`
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[baserow]`)
